### PR TITLE
Feat: 이어서 작업하기 API

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
+++ b/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
@@ -1,15 +1,7 @@
 package io.ejangs.docsa.domain.block.entity;
 
 import io.ejangs.docsa.domain.document.entity.Document;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,8 +23,10 @@ public class Block {
     @Column(nullable = false)
     private String type;
 
+    @Lob
     private String data;
 
+    @Lob
     private String tunes;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
+++ b/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
@@ -24,9 +24,11 @@ public class Block {
     private String type;
 
     @Lob
+    @Column(columnDefinition = "TEXT")
     private String data;
 
     @Lob
+    @Column(columnDefinition = "TEXT")
     private String tunes;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
+++ b/src/main/java/io/ejangs/docsa/domain/block/entity/Block.java
@@ -33,6 +33,8 @@ public class Block {
 
     private String data;
 
+    private String tunes;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id")
     private Document document;

--- a/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
@@ -1,0 +1,25 @@
+package io.ejangs.docsa.domain.branch.api;
+
+import io.ejangs.docsa.domain.branch.app.BranchService;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/document/{documentId}/branch")
+public class BranchController {
+
+    private final BranchService branchService;
+
+    @PostMapping
+    public ResponseEntity<BranchCreateResponse> createBranch(@PathVariable Long documentId,
+            @Valid @RequestBody BranchCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(branchService.createBranch(documentId, request));
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -12,6 +12,7 @@ import io.ejangs.docsa.domain.document.dao.DocumentRepository;
 import io.ejangs.docsa.domain.commit.dao.CommitRepository;
 import io.ejangs.docsa.domain.branch.dao.BranchRepository;
 import io.ejangs.docsa.global.exception.errorcode.DocumentErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
 import io.ejangs.docsa.domain.save.entity.Save;
 import io.ejangs.docsa.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -36,17 +37,17 @@ public class BranchService {
         Long fromId = request.fromCommitId();
         if (fromId != null) {
             Commit fromCommit = commitRepository.findById(fromId)
-                    .orElseThrow(() -> new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+                    .orElseThrow(() -> new CustomException(CommitErrorCode.COMMIT_NOT_FOUND));
 
             if (!fromCommit.getBranch().getDocument().getId().equals(documentId)) {
-                throw new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+                throw new CustomException(DocumentErrorCode.COMMIT_NOT_IN_DOCUMENT);
             }
 
             // fromCommit 브랜치의 leaf가 본인이면 최신 커밋
             boolean isLeaf = fromCommit.getBranch().getLeafCommit() != null
                     && fromCommit.getBranch().getLeafCommit().getId().equals(fromId);
 
-            // 최신커밋이면 있던 브랜치에 저장 만들기, 아니면 개로운 브랜치에 저장 만들기
+            // 최신커밋이면 있던 브랜치에 저장 만들기, 아니면 새로운 브랜치에 저장 만들기
             if (isLeaf) return createSaveAndResponse(fromCommit.getBranch(),commitContentAssembler.assemble(fromCommit));
             else {
                 Branch newBranch = branchRepository.save(BranchMapper.toEntity(request, document, fromCommit));

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -1,0 +1,71 @@
+package io.ejangs.docsa.domain.branch.app;
+
+import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.branch.util.BranchMapper;
+import io.ejangs.docsa.domain.commit.app.CommitContentAssembler;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.document.entity.Document;
+import io.ejangs.docsa.domain.save.dao.SaveRepository;
+import io.ejangs.docsa.domain.document.dao.DocumentRepository;
+import io.ejangs.docsa.domain.commit.dao.CommitRepository;
+import io.ejangs.docsa.domain.branch.dao.BranchRepository;
+import io.ejangs.docsa.global.exception.errorcode.DocumentErrorCode;
+import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BranchService {
+    private final DocumentRepository documentRepository;
+    private final CommitRepository commitRepository;
+    private final BranchRepository branchRepository;
+    private final SaveRepository saveRepository;
+    private final CommitContentAssembler commitContentAssembler;
+
+    @Transactional
+    public BranchCreateResponse createBranch(Long documentId,
+            BranchCreateRequest request) {
+        Document document = documentRepository.findById(documentId)
+                .orElseThrow(() -> new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+
+        Long fromId = request.fromCommitId();
+        if (fromId != null) {
+            Commit fromCommit = commitRepository.findById(fromId)
+                    .orElseThrow(() -> new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+
+            if (!fromCommit.getBranch().getDocument().getId().equals(documentId)) {
+                throw new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+            }
+
+            // fromCommit 브랜치의 leaf가 본인이면 최신 커밋
+            boolean isLeaf = fromCommit.getBranch().getLeafCommit() != null
+                    && fromCommit.getBranch().getLeafCommit().getId().equals(fromId);
+
+            // 최신커밋이면 있던 브랜치에 저장 만들기, 아니면 개로운 브랜치에 저장 만들기
+            if (isLeaf) return createSaveAndResponse(fromCommit.getBranch(),commitContentAssembler.assemble(fromCommit));
+            else {
+                Branch newBranch = branchRepository.save(BranchMapper.toEntity(request, document, fromCommit));
+                return createSaveAndResponse(newBranch,commitContentAssembler.assemble(fromCommit));
+            }
+        }
+        // fromId가 null이면 최초 새 브랜치 생성 + 저장 만들기
+        Branch newBranch = branchRepository.save(BranchMapper.toEntity(request, document, null));
+        return createSaveAndResponse(newBranch, "");
+    }
+
+    private BranchCreateResponse createSaveAndResponse(Branch branch, String content) {
+        Save save = Save.builder()
+                .content(content)
+                .branch(branch)
+                .build();
+        save = saveRepository.save(save);
+        return BranchMapper.toBranchCreateResponse(branch, save);
+    }
+}
+
+

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/BranchRepository.java
@@ -2,7 +2,5 @@ package io.ejangs.docsa.domain.branch.dao;
 
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface BranchRepository extends JpaRepository<Branch, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/BranchRepository.java
@@ -1,0 +1,8 @@
+package io.ejangs.docsa.domain.branch.dao;
+
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BranchRepository extends JpaRepository<Branch, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateRequest.java
@@ -1,0 +1,11 @@
+package io.ejangs.docsa.domain.branch.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record BranchCreateRequest(
+        @NotBlank(message = "브랜치 이름은 필수입니다")
+        @Size(max = 50, message = "브랜치이름은 50자를 초과 할 수 없습니다.")
+        String name,
+        Long fromCommitId
+) {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateResponse.java
@@ -2,5 +2,5 @@ package io.ejangs.docsa.domain.branch.dto;
 
 public record BranchCreateResponse(
         Long branchId,
-        Long tempId
+        Long SaveId
 ) {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateResponse.java
@@ -1,0 +1,6 @@
+package io.ejangs.docsa.domain.branch.dto;
+
+public record BranchCreateResponse(
+        Long branchId,
+        Long tempId
+) {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
@@ -15,15 +15,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter

--- a/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
@@ -35,7 +35,7 @@ public class Branch extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(length = 50, nullable = false)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/ejangs/docsa/domain/branch/util/BranchMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/util/BranchMapper.java
@@ -1,0 +1,19 @@
+package io.ejangs.docsa.domain.branch.util;
+
+import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.document.entity.Document;
+import io.ejangs.docsa.domain.save.entity.Save;
+
+public final class BranchMapper {
+
+    public static Branch toEntity(BranchCreateRequest dto, Document document, Commit fromCommit) {
+        return Branch.builder().name(dto.name()).document(document).fromCommit(fromCommit).build();
+    }
+
+    public static BranchCreateResponse toBranchCreateResponse(Branch branch, Save save) {
+        return new BranchCreateResponse(branch.getId(), save.getId());
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
@@ -65,7 +65,20 @@ public class CommitContentAssembler {
                     throw new CustomException(DocumentErrorCode.JSON_SERIALIZATION_FAILED);
                 }
             } else {
-                node.put("data", rawData);
+                node.put("data", objectMapper.createObjectNode());
+            }
+            // tunes 필드 처리
+            String rawTunes = blk.getTunes();
+            if (rawTunes != null && rawTunes.trim().startsWith("{")) {
+                try {
+                    JsonNode tunesNode = objectMapper.readTree(rawTunes);
+                    node.set("tunes", tunesNode);
+                } catch (JsonProcessingException e) {
+                    throw new CustomException(DocumentErrorCode.JSON_SERIALIZATION_FAILED);
+                }
+            } else {
+                // tunes가 없으면 빈 객체로
+                node.set("tunes", objectMapper.createObjectNode());
             }
 
             array.add(node);

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
@@ -13,14 +13,14 @@ import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.BlockErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.DocumentErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommitContentAssembler {
@@ -47,7 +47,7 @@ public class CommitContentAssembler {
 
         ArrayNode array = objectMapper.createArrayNode();
 
-        while (cur != null) {
+        while (true) {
             Block blk = cur.getCurrentBlock();
 
             // ObjectNode 생성

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitContentAssembler.java
@@ -1,0 +1,53 @@
+package io.ejangs.docsa.domain.commit.app;
+
+import io.ejangs.docsa.domain.block.entity.Block;
+import io.ejangs.docsa.domain.commit.dao.CommitBlockSequenceRepository;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.commit.entity.CommitBlockSequence;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommitContentAssembler {
+    private final CommitBlockSequenceRepository cbsRepository;
+
+    public String assemble(Commit commit) {
+        List<CommitBlockSequence> seqs = cbsRepository.findByCommit(commit);
+        if (seqs.isEmpty()) return "";
+
+        Map<Long, CommitBlockSequence> cbsMap =
+                seqs.stream().collect(Collectors.toMap(
+                        s -> s.getCurrentBlock().getId(), s -> s
+                ));
+
+        CommitBlockSequence cur = null;
+        for (CommitBlockSequence seq : seqs) {
+            if (seq.getFirst()) {
+                cur = seq;
+                break;
+            }
+        }
+        if (cur == null) {
+            throw new IllegalStateException("첫 블록이 없습니다");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        while (cur != null) {
+            sb.append(cur.getCurrentBlock().getData());
+            Block next = cur.getNextBlock();
+            if (next == null) break;
+            cur = cbsMap.get(next.getId());
+        }
+        return sb.toString();
+    }
+
+
+}
+

--- a/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitBlockSequenceRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitBlockSequenceRepository.java
@@ -1,0 +1,11 @@
+package io.ejangs.docsa.domain.commit.dao;
+
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.commit.entity.CommitBlockSequence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommitBlockSequenceRepository extends JpaRepository<CommitBlockSequence, Long> {
+    List<CommitBlockSequence> findByCommit(Commit commit);
+}

--- a/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitRepository.java
@@ -2,7 +2,5 @@ package io.ejangs.docsa.domain.commit.dao;
 
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CommitRepository extends JpaRepository<Commit, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/dao/CommitRepository.java
@@ -1,0 +1,8 @@
+package io.ejangs.docsa.domain.commit.dao;
+
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommitRepository extends JpaRepository<Commit, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/document/dao/DocumentRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/document/dao/DocumentRepository.java
@@ -2,7 +2,5 @@ package io.ejangs.docsa.domain.document.dao;
 
 import io.ejangs.docsa.domain.document.entity.Document;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/document/dao/DocumentRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/document/dao/DocumentRepository.java
@@ -1,0 +1,8 @@
+package io.ejangs.docsa.domain.document.dao;
+
+import io.ejangs.docsa.domain.document.entity.Document;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/save/dao/SaveRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/dao/SaveRepository.java
@@ -1,0 +1,8 @@
+package io.ejangs.docsa.domain.save.dao;
+
+import io.ejangs.docsa.domain.save.entity.Save;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SaveRepository extends JpaRepository<Save, Long> {}

--- a/src/main/java/io/ejangs/docsa/domain/save/dao/SaveRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/dao/SaveRepository.java
@@ -4,5 +4,4 @@ import io.ejangs.docsa.domain.save.entity.Save;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SaveRepository extends JpaRepository<Save, Long> {}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/BlockErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/BlockErrorCode.java
@@ -1,0 +1,17 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlockErrorCode implements ErrorCode {
+
+    BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문단 블럭을 찾을 수 없습니다.", "BLOCK_NOT_FOUND"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
@@ -1,0 +1,17 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BranchErrorCode implements ErrorCode {
+
+    BRANCH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 브랜치를 찾을 수 없습니다.", "BRANCH_NOT_FOUND"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/CommitErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/CommitErrorCode.java
@@ -1,0 +1,17 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommitErrorCode implements ErrorCode {
+
+    COMMIT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기록을 찾을 수 없습니다.", "COMMIT_NOT_FOUND"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum DocumentErrorCode implements ErrorCode {
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문서를 찾을 수 없습니다.", "DOCUMENT_NOT_FOUND"),
-    JSON_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 직렬화에 실패했습니다.", "JSON_SERIALIZATION_FAILED");
-
+    JSON_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 직렬화에 실패했습니다.", "JSON_SERIALIZATION_FAILED"),
+    COMMIT_NOT_IN_DOCUMENT(HttpStatus.BAD_REQUEST, "커밋이 해당 문서에 속해있지 않습니다", "COMMIT_NOT_IN_DOCUMENT");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
@@ -1,0 +1,15 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DocumentErrorCode implements ErrorCode {
+    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문서를 찾을 수 없습니다.", "DOCUMENT_NOT_FOUND");
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum DocumentErrorCode implements ErrorCode {
-    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문서를 찾을 수 없습니다.", "DOCUMENT_NOT_FOUND");
+    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문서를 찾을 수 없습니다.", "DOCUMENT_NOT_FOUND"),
+    JSON_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 직렬화에 실패했습니다.", "JSON_SERIALIZATION_FAILED");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
@@ -1,0 +1,52 @@
+package io.ejangs.docsa.domain.branch.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ejangs.docsa.domain.branch.app.BranchService;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BranchController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class BranchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BranchService branchService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("POST /api/document/{id}/branch → 201 + body")
+    void createBranch_returns201() throws Exception {
+        long docId = 42L;
+
+        BranchCreateRequest req = new BranchCreateRequest("new-branch", null);
+        BranchCreateResponse resp = new BranchCreateResponse(99L, 123L);
+
+        Mockito.when(branchService.createBranch(eq(docId), any(BranchCreateRequest.class)))
+                .thenReturn(resp);
+
+        mockMvc.perform(post("/api/document/{documentId}/branch", docId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.branchId").value(99))
+                .andExpect(jsonPath("$.tempId").value(123));
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/branch/app/BranchServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/branch/app/BranchServiceTest.java
@@ -1,0 +1,194 @@
+package io.ejangs.docsa.domain.branch.app;
+
+import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.commit.app.CommitContentAssembler;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.document.entity.Document;
+import io.ejangs.docsa.domain.document.dao.DocumentRepository;
+import io.ejangs.docsa.domain.branch.dao.BranchRepository;
+import io.ejangs.docsa.domain.commit.dao.CommitRepository;
+import io.ejangs.docsa.domain.save.dao.SaveRepository;
+import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.DocumentErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BranchServiceTest {
+
+    @Mock private DocumentRepository documentRepository;
+    @Mock private CommitRepository commitRepository;
+    @Mock private BranchRepository branchRepository;
+    @Mock private SaveRepository saveRepository;
+    @Mock private CommitContentAssembler assembler;
+
+    @InjectMocks
+    private BranchService service;
+
+    private Document doc;
+    private Branch existingBranch;
+    private Commit fromCommit;
+    private Branch newBranch;
+
+    @BeforeEach
+    void setUp() {
+        doc = Document.builder().title("D").build();
+        ReflectionTestUtils.setField(doc, "id", 1L);
+        lenient().when(documentRepository.findById(1L))
+                .thenReturn(Optional.of(doc));
+
+        existingBranch = Branch.builder()
+                .name("b1")
+                .document(doc)
+                .fromCommit(null)
+                .build();
+        ReflectionTestUtils.setField(existingBranch, "id", 100L);
+
+        fromCommit = Commit.builder()
+                .title("c")
+                .description("d")
+                .branch(existingBranch)
+                .build();
+        ReflectionTestUtils.setField(fromCommit, "id", 10L);
+
+        ReflectionTestUtils.setField(existingBranch, "leafCommit", fromCommit);
+
+        newBranch = Branch.builder()
+                .name("b2")
+                .document(doc)
+                .fromCommit(fromCommit)
+                .build();
+        ReflectionTestUtils.setField(newBranch, "id", 200L);
+    }
+
+    @Test
+    @DisplayName("fromCommitId null → 새 브랜치 + 빈 content 반환")
+    void whenFromIdNull_createNewBranchWithEmptyContent() {
+        when(branchRepository.save(any(Branch.class)))
+                .thenReturn(newBranch);
+
+        Save blankSave = Save.builder()
+                .content("")
+                .branch(newBranch)
+                .build();
+        ReflectionTestUtils.setField(blankSave, "id", 300L);
+        when(saveRepository.save(any(Save.class)))
+                .thenReturn(blankSave);
+
+        BranchCreateRequest req = new BranchCreateRequest("b-new", null);
+        BranchCreateResponse resp = service.createBranch(1L, req);
+
+        assertThat(resp.branchId()).isEqualTo(200L);
+        assertThat(resp.tempId()).isEqualTo(300L);
+
+        verify(branchRepository).save(argThat(b -> b.getName().equals("b-new")));
+        verify(saveRepository).save(argThat(s -> s.getContent().equals("")));
+        verifyNoMoreInteractions(commitRepository, assembler);
+    }
+
+    @Test
+    @DisplayName("fromCommitId leaf → 기존 브랜치 + assembled content 반환")
+    void whenFromIdIsLeaf_useExistingBranch() {
+        when(commitRepository.findById(10L))
+                .thenReturn(Optional.of(fromCommit));
+
+        when(assembler.assemble(fromCommit))
+                .thenReturn("assembled");
+
+        Save leafSave = Save.builder()
+                .content("assembled")
+                .branch(existingBranch)
+                .build();
+        ReflectionTestUtils.setField(leafSave, "id", 301L);
+        when(saveRepository.save(any(Save.class)))
+                .thenReturn(leafSave);
+
+        BranchCreateRequest req = new BranchCreateRequest("ignored", 10L);
+        BranchCreateResponse resp = service.createBranch(1L, req);
+
+        assertThat(resp.branchId()).isEqualTo(100L);
+        assertThat(resp.tempId()).isEqualTo(301L);
+
+        verify(commitRepository).findById(10L);
+        verify(assembler).assemble(fromCommit);
+        verify(saveRepository).save(argThat(s -> s.getBranch().equals(existingBranch)));
+        verifyNoMoreInteractions(branchRepository);
+    }
+
+    @Test
+    @DisplayName("fromCommitId non-leaf → 새 브랜치 + assembled content 반환")
+    void whenFromIdNotLeaf_createBranchFromCommit() {
+
+        ReflectionTestUtils.setField(existingBranch, "leafCommit", null);
+
+        when(commitRepository.findById(10L))
+                .thenReturn(Optional.of(fromCommit));
+
+        when(assembler.assemble(fromCommit))
+                .thenReturn("assembled2");
+
+        when(branchRepository.save(any(Branch.class)))
+                .thenReturn(newBranch);
+
+        Save newSave = Save.builder()
+                .content("assembled2")
+                .branch(newBranch)
+                .build();
+        ReflectionTestUtils.setField(newSave, "id", 302L);
+        when(saveRepository.save(any(Save.class)))
+                .thenReturn(newSave);
+
+        BranchCreateRequest req = new BranchCreateRequest("b3", 10L);
+        BranchCreateResponse resp = service.createBranch(1L, req);
+
+        assertThat(resp.branchId()).isEqualTo(200L);
+        assertThat(resp.tempId()).isEqualTo(302L);
+
+        verify(commitRepository).findById(10L);
+        verify(branchRepository).save(any(Branch.class));
+        verify(saveRepository).save(argThat(s -> s.getBranch().equals(newBranch)));
+    }
+
+    @Test
+    @DisplayName("문서가 없으면 NOT_FOUND 예외 발생")
+    void whenDocumentNotFound_throw() {
+        when(documentRepository.findById(2L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.createBranch(2L, new BranchCreateRequest("x", null))
+        )
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("커밋이 없으면 NOT_FOUND 예외 발생")
+    void whenCommitNotFound_throw() {
+        when(commitRepository.findById(20L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.createBranch(1L, new BranchCreateRequest("x", 20L))
+        )
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CommitContentAssemblerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CommitContentAssemblerTest.java
@@ -1,0 +1,86 @@
+package io.ejangs.docsa.domain.commit.app;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ejangs.docsa.domain.block.entity.Block;
+import io.ejangs.docsa.domain.commit.dao.CommitBlockSequenceRepository;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.commit.entity.CommitBlockSequence;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommitContentAssemblerTest {
+
+    @Mock
+    private CommitBlockSequenceRepository cbsRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private CommitContentAssembler assembler;
+
+    private Commit fakeCommit;
+
+    @BeforeEach
+    void setUp() {
+        fakeCommit = Commit.builder().title("테스트 커밋").description("desc").branch(null).build();
+    }
+
+    @Test
+    void assemble_withTwoBlocks_producesExpectedJsonArray() throws Exception {
+
+        Block b1 = Block.builder().uniqueId("mhTl6ghSkV").type("paragraph")
+                .data("{\"text\":\"First block\"}").document(null).build();
+        Block b2 = Block.builder().uniqueId("os_YI4eub4").type("list")
+                .data("{\"type\":\"unordered\",\"items\":[\"A\",\"B\"]}").document(null).build();
+
+        ReflectionTestUtils.setField(b1, "id", 1L);
+        ReflectionTestUtils.setField(b2, "id", 2L);
+
+        //CommitBlockSequence 두 건(순서, next 연결) 만들기
+        CommitBlockSequence seq1 =
+                CommitBlockSequence.builder().currentBlock(b1).first(true).nextBlock(b2).build();
+        CommitBlockSequence seq2 =
+                CommitBlockSequence.builder().currentBlock(b2).first(false).nextBlock(null).build();
+
+        List<CommitBlockSequence> seqs = Arrays.asList(seq1, seq2);
+
+        when(cbsRepository.findByCommit(fakeCommit)).thenReturn(seqs);
+
+        assembler = new CommitContentAssembler(cbsRepository, new ObjectMapper());
+
+        // assemble 호출
+        String json = assembler.assemble(fakeCommit);
+
+        // Jackson으로 파싱해서 검증
+        JsonNode root = new ObjectMapper().readTree(json);
+        assertTrue(root.isArray());
+        assertEquals(2, root.size());
+
+        JsonNode first = root.get(0);
+        assertEquals("mhTl6ghSkV", first.get("id").asText());
+        assertEquals("paragraph", first.get("type").asText());
+        assertEquals("First block", first.get("data").get("text").asText());
+
+        JsonNode second = root.get(1);
+        assertEquals("os_YI4eub4", second.get("id").asText());
+        assertEquals("list", second.get("type").asText());
+        assertTrue(second.get("data").get("items").isArray());
+        assertEquals("A", second.get("data").get("items").get(0).asText());
+        assertEquals("B", second.get("data").get("items").get(1).asText());
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #4 

## 🪐 작업 내용
### **CommitContentAssembler 생성**
  - 한 커밋을 조회하기 위해 해당 커밋의 문단을 조합하는 메서드입니다. 
  - 저장 생성, 커밋 조회, 비교하기, 머지하기 등 전역으로 사용할 일이 많아 commit 도메인의 app에 분리하였습니다.
  - 시퀀스리스트를 O(1)탐색하기 위해 Map 에 넣은 뒤 첫 블록부터 stringbuilder로 이어붙인 본문을 string으로 반환합니다.
  - JSON<->Sting 변환을 StringBuilder -> ObjectMapper 방식으로 수정하고 테스트 완료하였습니다.
  - 아래 ObjectMapper에 대한 설명이 있는 참고링크를 남깁니다.

### **이어서 작업하기 API**
- 최신 커밋에서 작업시 fromCommit 본문을 저장
- 최초 커밋 또는 이전 커밋에서 작업시 새로운 브랜치를 만들고 fromCommit 내용을 저장

- Branch 서비스와 컨트롤러 테스트, CommitContentAssembler 테스트 완료

## 📚 Reference

https://www.baeldung.com/jackson-object-mapper-tutorial

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?