### PR TITLE
Feat: 회원가입 인증코드 전송 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/io/ejangs/docsa/domain/auth/api/AuthController.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/api/AuthController.java
@@ -1,0 +1,26 @@
+package io.ejangs.docsa.domain.auth.api;
+
+import io.ejangs.docsa.domain.auth.app.AuthService;
+import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/code")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup-email")
+    public ResponseEntity<Void> sendSignupCode(@Valid @RequestBody SignupCodeRequest request) throws MessagingException {
+        authService.sendSignupCode(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
@@ -7,6 +7,7 @@ import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
 import jakarta.mail.MessagingException;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +19,8 @@ public class AuthService {
     private final MailService mailService;
     private final CacheManager cacheManager;
 
-    private static final String SIGNUP_CACHE_NAME = "signupCodeCache";
+    @Value("${auth.signup-code-cache-name}")
+    private String signupCacheName;
 
     public void sendSignupCode(SignupCodeRequest request) throws MessagingException {
 
@@ -27,7 +29,7 @@ public class AuthService {
         }
 
         String code = generateVerifyCode();
-        cacheManager.getCache(SIGNUP_CACHE_NAME).put(request.email(), code);
+        cacheManager.getCache(signupCacheName).put(request.email(), code);
         mailService.sendSignupAuthCode(request.email(), code);
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
@@ -1,0 +1,48 @@
+package io.ejangs.docsa.domain.auth.app;
+
+import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import io.ejangs.docsa.domain.user.dao.UserRepository;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import jakarta.mail.MessagingException;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final MailService mailService;
+    private final CacheManager cacheManager;
+
+    private static final String SIGNUP_CACHE_NAME = "signupCodeCache";
+
+    public void sendSignupCode(SignupCodeRequest request) throws MessagingException {
+
+        if (userRepository.existsByEmail(request.email())) {
+            throw new CustomException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+
+        String code = generateVerifyCode();
+        cacheManager.getCache(SIGNUP_CACHE_NAME).put(request.email(), code);
+        mailService.sendSignupAuthCode(request.email(), code);
+    }
+
+    private String generateVerifyCode() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            int index = random.nextInt(2);
+
+            switch (index) {
+                case 0 -> key.append((char) (random.nextInt(26) + 65)); // A-Z
+                case 1 -> key.append(random.nextInt(10)); // 0-9
+            }
+        }
+        return key.toString();
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/auth/app/MailService.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/app/MailService.java
@@ -1,0 +1,41 @@
+package io.ejangs.docsa.domain.auth.app;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendSignupAuthCode(String to, String authCode) throws MessagingException {
+        MimeMessage message = createSignupCodeMail(to, authCode);
+        javaMailSender.send(message);
+    }
+
+    private MimeMessage createSignupCodeMail(String to, String authCode) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.setRecipients(MimeMessage.RecipientType.TO, to);
+        message.setSubject("Docsa 이메일 인증");
+
+        String body = """
+            <h3>요청하신 인증 번호입니다.</h3>
+            <h1>%s</h1>
+            <h3>감사합니다.</h3>
+            """.formatted(authCode);
+
+        message.setText(body, "UTF-8", "html");
+
+        return message;
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/auth/dto/request/SignupCodeRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/dto/request/SignupCodeRequest.java
@@ -4,7 +4,10 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignupCodeRequest(
-        @NotBlank @Email String email
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email
 ) {
 
 }

--- a/src/main/java/io/ejangs/docsa/domain/auth/dto/request/SignupCodeRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/dto/request/SignupCodeRequest.java
@@ -1,0 +1,10 @@
+package io.ejangs.docsa.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupCodeRequest(
+        @NotBlank @Email String email
+) {
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/user/dao/UserRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/user/dao/UserRepository.java
@@ -1,0 +1,9 @@
+package io.ejangs.docsa.domain.user.dao;
+
+import io.ejangs.docsa.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/io/ejangs/docsa/global/config/CacheConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package io.ejangs.docsa.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("signupCodeCache");
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder()
+                        .expireAfterWrite(3, TimeUnit.MINUTES)
+                        .maximumSize(1000)
+        );
+        return cacheManager;
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/config/MailConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/MailConfig.java
@@ -1,0 +1,67 @@
+package io.ejangs.docsa.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package io.ejangs.docsa.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(
+                        session -> session
+                                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                                .maximumSessions(1)
+                                .maxSessionsPreventsLogin(false))
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/api/user/signup", "/api/user/login", "/api/auth/code/signup-email").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .logout(logout -> logout
+                        .logoutUrl("/api/user/logout")
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                        .clearAuthentication(true)
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
                                 .maximumSessions(1)
                                 .maxSessionsPreventsLogin(false))
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/user/signup", "/api/user/login", "/api/auth/code/signup-email").permitAll()
+                        .requestMatchers("/api/user/signup", "/api/user/login",
+                                "/api/auth/code/signup-email").anonymous()
                         .anyRequest().authenticated()
                 )
                 .formLogin(formLogin -> formLogin.disable())
@@ -54,8 +55,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin("http://localhost:3000");
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedOrigins(
+                List.of("http://localhost:3000", "https://web5-7-2jangs-fe.pages.dev/"));
+        configuration.setAllowedMethods(
+                List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다.", "DUPLICATE_EMAIL");
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,6 @@ spring:
           timeout: 5000
           writetimeout: 5000
       auth-code-expiration-millis: 180000  # 3분
+
+auth:
+  signup-code-cache-name: signupCodeCache

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,20 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create-drop
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 180000  # 3분

--- a/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
@@ -1,0 +1,129 @@
+package io.ejangs.docsa.domain.auth.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ejangs.docsa.domain.auth.app.AuthService;
+import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입 시 인증코드 전송 요청 성공")
+    void sendSignupCode_Success() throws Exception {
+        // given
+        SignupCodeRequest request = new SignupCodeRequest("test@example.com");
+
+        doNothing().when(authService).sendSignupCode(request);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/signup-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""))
+                .andDo(print());
+
+        verify(authService).sendSignupCode(request);
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일 형식으로 요청 시 400 에러 발생")
+    void sendSignupCode_InvalidEmail() throws Exception {
+        // given
+        SignupCodeRequest request = new SignupCodeRequest("invalid-email");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/signup-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        verify(authService, never()).sendSignupCode(any());
+    }
+
+    @Test
+    @DisplayName("이메일이 null인 경우 400 에러 발생")
+    void sendSignupCode_NullEmail() throws Exception {
+        // given
+        String requestBody = "{\"email\": null}";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/signup-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        verify(authService, never()).sendSignupCode(any());
+    }
+
+    @Test
+    @DisplayName("이메일이 빈 문자열인 경우 400 에러")
+    void sendSignupCode_EmptyEmail() throws Exception {
+        // given
+        SignupCodeRequest request = new SignupCodeRequest("");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/signup-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        verify(authService, never()).sendSignupCode(any());
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 요청 시 400 에러 발생")
+    void sendSignupCode_DuplicateEmail() throws Exception {
+        // given
+        SignupCodeRequest request = new SignupCodeRequest("test@example.com");
+
+        doThrow(new CustomException(AuthErrorCode.DUPLICATE_EMAIL))
+                .when(authService).sendSignupCode(request);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/signup-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."))
+                .andExpect(jsonPath("$.error").value("DUPLICATE_EMAIL"))
+                .andDo(print());
+
+        verify(authService).sendSignupCode(request);
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/auth/app/AuthServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/app/AuthServiceTest.java
@@ -1,0 +1,100 @@
+package io.ejangs.docsa.domain.auth.app;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import io.ejangs.docsa.domain.user.dao.UserRepository;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import jakarta.mail.MessagingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MailService mailService;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache signupCodeCache;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private SignupCodeRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new SignupCodeRequest("test@example.com");
+        lenient().when(cacheManager.getCache("signupCodeCache")).thenReturn(signupCodeCache);
+    }
+
+    @Test
+    @DisplayName("정상적인 인증코드 전송")
+    void sendSignupCode_Success() throws MessagingException {
+        // given
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+
+        // when
+        authService.sendSignupCode(request);
+
+        // then
+        verify(userRepository).existsByEmail(request.email());
+        verify(signupCodeCache).put(eq(request.email()), any(String.class));
+        verify(mailService).sendSignupAuthCode(eq(request.email()), any(String.class));
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 요청 시 예외 발생")
+    void sendSignupCode_DuplicateEmail() throws MessagingException {
+        // given
+        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> authService.sendSignupCode(request))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.DUPLICATE_EMAIL);
+
+        verify(userRepository).existsByEmail(request.email());
+        verify(signupCodeCache, never()).put(any(), any());
+        verify(mailService, never()).sendSignupAuthCode(any(), any());
+    }
+
+    @Test
+    @DisplayName("메일 전송 실패 시 예외 발생")
+    void sendSignupCode_MailSendingFailed() throws MessagingException {
+        // given
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        doThrow(new MessagingException("Mail server error"))
+                .when(mailService).sendSignupAuthCode(any(), any());
+
+        // when & then
+        assertThatThrownBy(() -> authService.sendSignupCode(request))
+                .isInstanceOf(MessagingException.class)
+                .hasMessage("Mail server error");
+
+        verify(signupCodeCache).put(eq(request.email()), any(String.class));
+        verify(mailService).sendSignupAuthCode(eq(request.email()), any(String.class));
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/auth/app/MailServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/app/MailServiceTest.java
@@ -1,0 +1,130 @@
+package io.ejangs.docsa.domain.auth.app;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private MimeMessage mimeMessage;
+
+    @InjectMocks
+    private MailService mailService;
+
+    @BeforeEach
+    void setUp() {
+        // @Value 어노테이션 필드 수동 설정
+        ReflectionTestUtils.setField(mailService, "senderEmail", "sender@example.com");
+    }
+
+    @Test
+    @DisplayName("인증코드 메일 전송 성공")
+    void sendSignupAuthCode_Success() throws MessagingException {
+        // given
+        String recipientEmail = "test@example.com";
+        String authCode = "123456";
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailService.sendSignupAuthCode(recipientEmail, authCode);
+
+        // then
+        verify(javaMailSender).createMimeMessage();
+        verify(javaMailSender).send(mimeMessage);
+
+        // MimeMessage 설정 검증
+        verify(mimeMessage).setFrom("sender@example.com");
+        verify(mimeMessage).setRecipients(MimeMessage.RecipientType.TO, recipientEmail);
+        verify(mimeMessage).setSubject("Docsa 이메일 인증");
+        verify(mimeMessage).setText(argThat(body ->
+                body.contains(authCode) && body.contains("인증 번호")
+        ), eq("UTF-8"), eq("html"));
+    }
+
+    @Test
+    @DisplayName("MimeMessage 생성 실패 시 예외 발생")
+    void sendSignupAuthCode_MimeMessageCreationFailed() throws MessagingException {
+        // given
+        String recipientEmail = "test@example.com";
+        String authCode = "123456";
+
+        when(javaMailSender.createMimeMessage()).thenThrow(new RuntimeException("Message creation failed"));
+
+        // when & then
+        assertThatThrownBy(() -> mailService.sendSignupAuthCode(recipientEmail, authCode))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Message creation failed");
+
+        verify(javaMailSender).createMimeMessage();
+        verify(javaMailSender, never()).send((MimeMessage) any());
+    }
+
+    @Test
+    @DisplayName("메일 전송 실패 시 예외 발생")
+    void sendSignupAuthCode_SendingFailed() throws MessagingException {
+        // given
+        String recipientEmail = "test@example.com";
+        String authCode = "123456";
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doThrow(new MailSendException("SMTP server error"))
+                .when(javaMailSender).send(mimeMessage);
+
+        // when & then
+        assertThatThrownBy(() -> mailService.sendSignupAuthCode(recipientEmail, authCode))
+                .isInstanceOf(MailSendException.class)
+                .hasMessage("SMTP server error");
+
+        verify(javaMailSender).createMimeMessage();
+        verify(javaMailSender).send(mimeMessage);
+    }
+
+    @Test
+    @DisplayName("메일 내용에 인증코드가 포함되어 있는지 확인")
+    void createSignupCodeMail_ContainsAuthCode() throws MessagingException {
+        // given
+        String recipientEmail = "test@example.com";
+        String authCode = "123456";
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailService.sendSignupAuthCode(recipientEmail, authCode);
+
+        // then
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mimeMessage).setText(bodyCaptor.capture(), eq("UTF-8"), eq("html"));
+
+        String capturedBody = bodyCaptor.getValue();
+        assertThat(capturedBody)
+                .contains("인증 번호")
+                .contains(authCode)
+                .contains("감사합니다");
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
close #8 

## 🪐 작업 내용
- 회원가입 시 필요한 인증코드 전송 api 구현했습니다.
- 인증 코드는 알파벳 대문자와 숫자로 구성된 6자리 난수로 만들었습니다.
- 인증 코드는 로컬 메모리 기반의 Caffeine Cache에 저장하도록 하였고 3분 후 만료되어 제거되도록 설정하였습니다. 

<img width="671" height="329" alt="스크린샷 2025-07-11 오전 3 58 56" src="https://github.com/user-attachments/assets/f3dd0ed6-d152-4ad9-a62f-91a62413ec2b" />

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?