### PR TITLE
Feat: 문서 저장 데이터 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
@@ -19,11 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/document/{documentId}/save/{saveId}")
 public class SaveController {
 
     private final SaveService saveService;
 
-    @GetMapping("/api/document/{documentId}/save/{saveId}")
+    @GetMapping
     public ResponseEntity<SaveGetResponse> getSave(@RequestParam Long userId,
             @PathVariable Long saveId,
             @PathVariable Long documentId) {
@@ -31,7 +32,7 @@ public class SaveController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PutMapping("/api/document/{documentId}/save/{saveId}")
+    @PutMapping
     public ResponseEntity<SaveUpdateResponse> updateSave(@RequestParam Long userId,
             @PathVariable Long documentId,
             @PathVariable Long saveId,

--- a/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
@@ -1,15 +1,19 @@
 package io.ejangs.docsa.domain.save.api;
 
 import io.ejangs.docsa.domain.save.app.SaveService;
+import io.ejangs.docsa.domain.save.dto.SaveGetIdDto;
 import io.ejangs.docsa.domain.save.dto.SaveUpdateIdDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
+import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +23,14 @@ public class SaveController {
 
     private final SaveService saveService;
 
+    @GetMapping("/api/document/{documentId}/save/{saveId}")
+    public ResponseEntity<SaveGetResponse> getSave(@RequestParam Long userId,
+            @PathVariable Long saveId,
+            @PathVariable Long documentId) {
+        SaveGetResponse response = saveService.getSave(SaveGetIdDto.of(documentId, saveId, userId));
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
     @PutMapping("/api/document/{documentId}/save/{saveId}")
     public ResponseEntity<SaveUpdateResponse> updateSave(@RequestParam Long userId,
             @PathVariable Long documentId,
@@ -26,8 +38,6 @@ public class SaveController {
             @RequestBody SaveUpdateRequest saveUpdateRequest) {
         SaveUpdateResponse response = saveService.updateSave(
                 SaveUpdateIdDto.of(documentId, saveId, userId), saveUpdateRequest);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
@@ -2,6 +2,8 @@ package io.ejangs.docsa.domain.save.app;
 
 import io.ejangs.docsa.domain.document.dao.DocumentRepository;
 import io.ejangs.docsa.domain.save.dao.SaveRepository;
+import io.ejangs.docsa.domain.save.dto.SaveGetIdDto;
+import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.SaveUpdateIdDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
@@ -24,6 +26,19 @@ public class SaveService {
     private final DocumentRepository documentRepository;
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
+    public SaveGetResponse getSave(SaveGetIdDto dto) {
+        userRepository.findById(dto.userId())
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        documentRepository.findById(dto.documentId())
+                .orElseThrow(() -> new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
+
+        Save findSave = getSaveOfThrow(dto.saveId());
+
+        return SaveMapper.toSaveGetResponse(findSave);
+    }
+
     @Transactional
     public SaveUpdateResponse updateSave(SaveUpdateIdDto dto, SaveUpdateRequest request) {
         userRepository.findById(dto.userId())
@@ -32,11 +47,16 @@ public class SaveService {
         documentRepository.findById(dto.documentId())
                 .orElseThrow(() -> new CustomException(DocumentErrorCode.DOCUMENT_NOT_FOUND));
 
-        Save findSave = saveRepository.findById(dto.saveId())
-                .orElseThrow(() -> new CustomException(SaveErrorCode.SAVE_NOT_FOUND));
+        Save findSave = getSaveOfThrow(dto.saveId());
 
         findSave.updateContent(request.content());
         saveRepository.flush(); // flush 을 통해 updatedAt 필드를 갱신해야 하므로 명시적으로 flush
         return SaveMapper.toSaveUpdateResponse(findSave);
+    }
+
+    // 다른 서비스에서도 사용할 수 있도록 public 으로 오픈
+    public Save getSaveOfThrow(Long saveId) {
+        return saveRepository.findById(saveId)
+                .orElseThrow(() -> new CustomException(SaveErrorCode.SAVE_NOT_FOUND));
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
@@ -3,9 +3,9 @@ package io.ejangs.docsa.domain.save.app;
 import io.ejangs.docsa.domain.document.dao.DocumentRepository;
 import io.ejangs.docsa.domain.save.dao.SaveRepository;
 import io.ejangs.docsa.domain.save.dto.SaveGetIdDto;
-import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.SaveUpdateIdDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
+import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
 import io.ejangs.docsa.domain.save.entity.Save;
 import io.ejangs.docsa.domain.save.util.SaveMapper;
@@ -28,6 +28,7 @@ public class SaveService {
 
     @Transactional(readOnly = true)
     public SaveGetResponse getSave(SaveGetIdDto dto) {
+        // TODO: 다른 도메인 서비스를 주입받을 때 existsById() 로 수정
         userRepository.findById(dto.userId())
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
@@ -41,6 +42,7 @@ public class SaveService {
 
     @Transactional
     public SaveUpdateResponse updateSave(SaveUpdateIdDto dto, SaveUpdateRequest request) {
+        // TODO: 다른 도메인 서비스를 주입받을 때 existsById() 로 수정
         userRepository.findById(dto.userId())
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/io/ejangs/docsa/domain/save/dto/SaveGetIdDto.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/dto/SaveGetIdDto.java
@@ -1,0 +1,8 @@
+package io.ejangs.docsa.domain.save.dto;
+
+public record SaveGetIdDto(Long documentId, Long saveId, Long userId) {
+
+    public static SaveGetIdDto of(Long documentId, Long saveId, Long userId) {
+        return new SaveGetIdDto(documentId, saveId, userId);
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/save/dto/response/SaveGetResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/dto/response/SaveGetResponse.java
@@ -1,0 +1,6 @@
+package io.ejangs.docsa.domain.save.dto.response;
+
+import java.time.OffsetDateTime;
+
+public record SaveGetResponse(OffsetDateTime updatedAt, String content) {
+}

--- a/src/main/java/io/ejangs/docsa/domain/save/util/SaveMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/util/SaveMapper.java
@@ -1,5 +1,6 @@
 package io.ejangs.docsa.domain.save.util;
 
+import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
 import io.ejangs.docsa.domain.save.entity.Save;
 import java.time.LocalDateTime;
@@ -9,11 +10,18 @@ import java.time.ZoneOffset;
 public class SaveMapper {
 
     public static SaveUpdateResponse toSaveUpdateResponse(Save save) {
-        LocalDateTime localDateTime = save.getUpdatedAt();
-        ZoneOffset offset = ZoneOffset.ofHours(9); // 예: KST 기준
-
-        OffsetDateTime updatedAt = localDateTime.atOffset(offset);
+        OffsetDateTime updatedAt = toOffsetDateTime(save.getUpdatedAt());
 
         return new SaveUpdateResponse(updatedAt);
+    }
+
+    public static SaveGetResponse toSaveGetResponse(Save save) {
+        OffsetDateTime updatedAt = toOffsetDateTime(save.getUpdatedAt());
+
+        return new SaveGetResponse(updatedAt, save.getContent());
+    }
+
+    private static OffsetDateTime toOffsetDateTime(LocalDateTime localDateTime) {
+        return localDateTime.atOffset(ZoneOffset.ofHours(9));
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceIntegrationTest.java
@@ -21,6 +21,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+/*
+JpaAuditing 작동을 통해 수정 시간을 직접 확인하고 싶어서
+불가피하게 통합테스트를 추가로 작성하였습니다.
+해당 테스트는 성공 케이스만 존재합니다.
+ */
 @SpringBootTest
 @Transactional
 class SaveServiceIntegrationTest {

--- a/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceUnitTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceUnitTest.java
@@ -1,24 +1,34 @@
 package io.ejangs.docsa.domain.save.app;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.document.dao.DocumentRepository;
 import io.ejangs.docsa.domain.document.entity.Document;
 import io.ejangs.docsa.domain.save.dao.SaveRepository;
+import io.ejangs.docsa.domain.save.dto.SaveGetIdDto;
 import io.ejangs.docsa.domain.save.dto.SaveUpdateIdDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
+import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
+import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.domain.save.util.SaveMapper;
 import io.ejangs.docsa.domain.user.dao.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,11 +44,13 @@ class SaveServiceUnitTest {
     private Document mockDocument;
     @Mock
     private User mockUser;
+    @Mock
+    private Branch mockBranch;
     @InjectMocks
     private SaveService saveService;
 
     @Test
-    @DisplayName("존재하지 않는 유저 ID로 수정 요청 시 예외가 발생한다")
+    @DisplayName("updateSave - 존재하지 않는 유저 ID로 수정 요청 시 예외가 발생한다")
     void updateSave_fail_invalidUser() {
         // given
         SaveUpdateIdDto dto = SaveUpdateIdDto.of(1L, 1L, -1L);
@@ -51,7 +63,7 @@ class SaveServiceUnitTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 문서 ID로 수정 요청 시 예외가 발생한다")
+    @DisplayName("updateSave - 존재하지 않는 문서 ID로 수정 요청 시 예외가 발생한다")
     void updateSave_fail_invalidDocument() {
         // given
         SaveUpdateIdDto dto = SaveUpdateIdDto.of(-1L, 1L, 1L);
@@ -66,7 +78,7 @@ class SaveServiceUnitTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 저장 ID로 수정 요청 시 예외가 발생한다")
+    @DisplayName("updateSave - 존재하지 않는 저장 ID로 수정 요청 시 예외가 발생한다")
     void updateSave_fail_invalidSave() {
         // given
         SaveUpdateIdDto dto = SaveUpdateIdDto.of(1L, -1L, 1L);
@@ -81,4 +93,72 @@ class SaveServiceUnitTest {
                 .hasMessageContaining("해당 저장 데이터를 찾을 수 없습니다.");
     }
 
+
+    @Test
+    @DisplayName("getSave - 성공적으로 save 조회")
+    void getSave_success() {
+        String content = "mock content";
+        SaveGetIdDto dto = SaveGetIdDto.of(1L, 1L, 1L);
+        Save save = Save.builder()
+                .branch(mockBranch)
+                .content(content)
+                .build();
+        SaveGetResponse expected = new SaveGetResponse(OffsetDateTime.now(), content);
+
+        when(userRepository.findById(dto.userId())).thenReturn(Optional.of(mockUser));
+        when(documentRepository.findById(dto.documentId())).thenReturn(Optional.of(mockDocument));
+        when(saveRepository.findById(dto.saveId())).thenReturn(Optional.of(save));
+        try (
+            MockedStatic<SaveMapper> saveMapper = mockStatic(SaveMapper.class);
+        ) {
+            saveMapper.when(() -> SaveMapper.toSaveGetResponse(save)).thenReturn(expected);
+
+            SaveGetResponse response = saveService.getSave(dto);
+
+            assertEquals(expected, response);
+        }
+    }
+
+    @Test
+    @DisplayName("getSave - 존재하지 않는 유저 ID로 조회 시 예외가 발생한다")
+    void getSave_fail_invalidUser() {
+        // given
+        SaveGetIdDto dto = SaveGetIdDto.of(1L, 1L, -1L);
+
+        // when & then
+        assertThatThrownBy(() -> saveService.getSave(dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("getSave - 존재하지 않는 문서 ID로 조회 시 예외가 발생한다")
+    void getSave_fail_invalidDocument() {
+        // given
+        SaveGetIdDto dto = SaveGetIdDto.of(1L, 1L, -1L);
+
+        // when
+        when(userRepository.findById(dto.userId())).thenReturn(Optional.of(mockUser));
+
+        // then
+        assertThatThrownBy(() -> saveService.getSave(dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("해당 문서를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("getSave - 존재하지 않는 저장 ID로 조회 시 예외가 발생한다")
+    void getSave_fail_invalidSave() {
+        // given
+        SaveGetIdDto dto = SaveGetIdDto.of(1L, 1L, -1L);
+
+        // when
+        when(userRepository.findById(dto.userId())).thenReturn(Optional.of(mockUser));
+        when(documentRepository.findById(dto.documentId())).thenReturn(Optional.of(mockDocument));
+
+        // then
+        assertThatThrownBy(() -> saveService.getSave(dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("해당 저장 데이터를 찾을 수 없습니다.");
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #18 

## 🪐 작업 내용
- 문서 저장 데이터는 본문이 전부 DB에 저장되어 있어, saveId 로 조회할 수 있습니다.
- controller, service unit test를 완료하였습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?