### PR TITLE
Feat: 브랜치 이름 수정 API

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
@@ -3,6 +3,8 @@ package io.ejangs.docsa.domain.branch.api;
 import io.ejangs.docsa.domain.branch.app.BranchService;
 import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
 import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.dto.BranchRenameRequest;
+import io.ejangs.docsa.domain.branch.dto.BranchRenameResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,4 +24,14 @@ public class BranchController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(branchService.createBranch(documentId, request));
     }
+
+    @PatchMapping("/{branchId}")
+    public ResponseEntity<BranchRenameResponse> renameBranch(
+            @PathVariable Long documentId,
+            @PathVariable Long branchId,
+            @Valid @RequestBody BranchRenameRequest request) {
+        return ResponseEntity.ok(branchService.renameBranch(documentId, branchId, request.newName()));
+
+    }
+
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record BranchCreateRequest(
         @NotBlank(message = "브랜치 이름은 필수입니다")
-        @Size(max = 50, message = "브랜치이름은 50자를 초과 할 수 없습니다.")
+        @Size(max = 100,  message = "브랜치이름은 100자를 초과 할 수 없습니다.")
         String name,
         Long fromCommitId
 ) {}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchRenameRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchRenameRequest.java
@@ -1,0 +1,11 @@
+package io.ejangs.docsa.domain.branch.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record BranchRenameRequest (
+    @NotBlank(message = "브랜치 이름은 빈 값일 수 없습니다")
+    @Size(max = 100, message = "브랜치이름은 100자를 초과 할 수 없습니다.")
+    String newName
+
+){}

--- a/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchRenameResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dto/BranchRenameResponse.java
@@ -1,0 +1,6 @@
+package io.ejangs.docsa.domain.branch.dto;
+
+public record BranchRenameResponse (
+        Long id,
+        String name
+){}

--- a/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
@@ -32,7 +32,7 @@ public class Branch extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 100, nullable = false)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -64,5 +64,8 @@ public class Branch extends BaseEntity {
 
     public void updateLeafCommit(Commit leafCommit) {
         this.leafCommit = leafCommit;
+    }
+    public void rename(String newName) {
+        this.name = newName;
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/util/BranchMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/util/BranchMapper.java
@@ -2,6 +2,7 @@ package io.ejangs.docsa.domain.branch.util;
 
 import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
 import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.dto.BranchRenameResponse;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.document.entity.Document;
@@ -15,5 +16,9 @@ public final class BranchMapper {
 
     public static BranchCreateResponse toBranchCreateResponse(Branch branch, Save save) {
         return new BranchCreateResponse(branch.getId(), save.getId());
+    }
+
+    public static BranchRenameResponse toBranchRenameResponse(Branch branch) {
+        return new BranchRenameResponse(branch.getId(), branch.getName());
     }
 }

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocumentErrorCode.java
@@ -10,7 +10,8 @@ public enum DocumentErrorCode implements ErrorCode {
 
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문서를 찾을 수 없습니다.", "DOCUMENT_NOT_FOUND"),
     JSON_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 직렬화에 실패했습니다.", "JSON_SERIALIZATION_FAILED"),
-    COMMIT_NOT_IN_DOCUMENT(HttpStatus.BAD_REQUEST, "커밋이 해당 문서에 속해있지 않습니다", "COMMIT_NOT_IN_DOCUMENT");
+    COMMIT_NOT_IN_DOCUMENT(HttpStatus.BAD_REQUEST, "커밋이 해당 문서에 속해있지 않습니다", "COMMIT_NOT_IN_DOCUMENT"),
+    BRANCH_NOT_IN_DOCUMENT(HttpStatus.BAD_REQUEST, "브랜치가 해당 문서에 속해있지 않습니다", "BRANCH_NOT_IN_DOCUMENT");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ejangs.docsa.domain.branch.app.BranchService;
 import io.ejangs.docsa.domain.branch.dto.BranchCreateRequest;
 import io.ejangs.docsa.domain.branch.dto.BranchCreateResponse;
+import io.ejangs.docsa.domain.branch.dto.BranchRenameResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,9 +15,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BranchController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -42,11 +46,38 @@ class BranchControllerTest {
         Mockito.when(branchService.createBranch(eq(docId), any(BranchCreateRequest.class)))
                 .thenReturn(resp);
 
-        mockMvc.perform(post("/api/document/{documentId}/branch", docId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.branchId").value(99))
+        mockMvc.perform(post("/api/document/{documentId}/branch", docId).contentType(
+                        MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.branchId").value(99))
                 .andExpect(jsonPath("$.saveId").value(123));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/document/{document_id}/branch/{branch_id} → 200")
+    void renameBranch_Success() throws Exception {
+        Long documentId = 5L;
+        Long branchId = 8L;
+        String newName = "updated-branch";
+
+        BranchRenameResponse resp = new BranchRenameResponse(branchId, newName);
+
+        Mockito.when(branchService.renameBranch(documentId, branchId, newName)).thenReturn(resp);
+
+        mockMvc.perform(patch("/api/document/{documentId}/branch/{branchId}", documentId,
+                        branchId).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newName\": \"" + newName + "\"}")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(branchId))
+                .andExpect(jsonPath("$.name").value(newName));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/document/{document_id}/branch/{branch_id} → 404")
+    void renameBranch_InvalidName() throws Exception {
+        Long documentId = 5L;
+        Long branchId = 8L;
+
+        mockMvc.perform(patch("/api/document/{documentId}/branch/{branchId}", documentId,
+                        branchId).contentType(MediaType.APPLICATION_JSON).content("{\"newName\": \"\"}"))
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #22 

## 🪐 작업 내용
브랜치 이름을 수정하는 API 구현입니다. 
컨트롤러, 서비스 단위테스트 완료했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?