### PR TITLE
Refactor: 문서 생성 시 브랜치/저장 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 모든 테스트 무시
+src/test/java/io/ejangs/docsa/domain/**
+
+# 예외: doc 하위만 포함 (doc 및 그 하위 파일들 포함)
+!src/test/java/io/ejangs/docsa/domain/doc/
+!src/test/java/io/ejangs/docsa/domain/doc/**

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-# 모든 테스트 무시
-src/test/java/io/ejangs/docsa/domain/**

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,3 @@ out/
 
 # 모든 테스트 무시
 src/test/java/io/ejangs/docsa/domain/**
-
-# 예외: doc 하위만 포함 (doc 및 그 하위 파일들 포함)
-!src/test/java/io/ejangs/docsa/domain/doc/
-!src/test/java/io/ejangs/docsa/domain/doc/**

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -1,5 +1,6 @@
 package io.ejangs.docsa.domain.doc.app;
 
+import com.mongodb.MongoTimeoutException;
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
@@ -21,10 +22,13 @@ import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DocService {
@@ -46,11 +50,20 @@ public class DocService {
         String title = request.title();
         checkTitleDuplicate(userId, title);
 
+        //Mongo 저장을 맨처음에 진행하여 실패시 예외 발생으로 인한 종료 -> 유사 트랜잭션
+        SaveContent defaultSaveContent;
+        try {
+            defaultSaveContent = createDefaultSaveContent();
+        } catch (MongoTimeoutException | DataAccessResourceFailureException e) {
+            log.error("DefaultSaveContent: Mongo 저장 실패 원인 - {}", e.getMessage());
+            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
+        }
+
         Doc doc = createDoc(user, title);
 
         Branch defaultBranch = createDefaultBranch(doc);
 
-        createDefaultSave(defaultBranch);
+        createDefaultSave(defaultBranch, defaultSaveContent);
 
         return DocMapper.toCreateResponse(doc);
     }
@@ -74,13 +87,15 @@ public class DocService {
         return branch;
     }
 
-    private void createDefaultSave(Branch branch) {
-        SaveContent saveContent = saveContentRepository.save(
+    private SaveContent createDefaultSaveContent() {
+        return saveContentRepository.save(
                 SaveContent.builder()
                         .content(new HashMap<>())
                         .build()
         );
+    }
 
+    private void createDefaultSave(Branch branch, SaveContent saveContent) {
         saveRepository.save(Save.builder()
                 .branch(branch)
                 .saveMongoId(saveContent.getId())

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -1,5 +1,7 @@
 package io.ejangs.docsa.domain.doc.app;
 
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
+import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dto.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.DocListSimpleResponse;
@@ -7,13 +9,19 @@ import io.ejangs.docsa.domain.doc.dto.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.util.DocMapper;
+import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
+import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
+import io.ejangs.docsa.domain.save.document.SaveContent;
+import io.ejangs.docsa.domain.save.entity.Save;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
+import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +31,12 @@ public class DocService {
 
     private final DocRepository docRepository;
     private final UserRepository userRepository;
+    private final BranchRepository branchRepository;
+    private final SaveRepository saveRepository;
+    private final SaveContentRepository saveContentRepository;
+
+    @Value("${default.branch}")
+    private String defaultBranchName;
 
     @Transactional
     public DocCreateResponse create(DocTitleRequest request, Long userId) {
@@ -32,17 +46,45 @@ public class DocService {
         String title = request.title();
         checkTitleDuplicate(userId, title);
 
-        Doc doc = Doc.builder()
+        Doc doc = createDoc(user, title);
+
+        Branch defaultBranch = createDefaultBranch(doc);
+
+        createDefaultSave(defaultBranch);
+
+        return DocMapper.toCreateResponse(doc);
+    }
+
+    private Doc createDoc(User user, String title) {
+        Doc doc = docRepository.save(Doc.builder()
                 .title(title)
                 .user(user)
-                .build();
-
-        Doc saved = docRepository.save(doc);
-
-        user.addDocument(saved);
+                .build());
+        user.addDocument(doc);
         user.touch();
+        return doc;
+    }
 
-        return DocMapper.toCreateResponse(saved);
+    private Branch createDefaultBranch(Doc doc) {
+        Branch branch = branchRepository.save(Branch.builder()
+                .name(defaultBranchName)
+                .doc(doc)
+                .build());
+        doc.addBranch(branch);
+        return branch;
+    }
+
+    private void createDefaultSave(Branch branch) {
+        SaveContent saveContent = saveContentRepository.save(
+                SaveContent.builder()
+                        .content(new HashMap<>())
+                        .build()
+        );
+
+        saveRepository.save(Save.builder()
+                .branch(branch)
+                .saveMongoId(saveContent.getId())
+                .build());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -25,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +86,7 @@ public class DocService {
                 .name(defaultBranchName)
                 .doc(doc)
                 .build());
+        branchRepository.flush();
         doc.addBranch(branch);
         return branch;
     }

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -1,6 +1,5 @@
 package io.ejangs.docsa.domain.doc.app;
 
-import com.mongodb.MongoTimeoutException;
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
@@ -24,7 +23,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,8 +60,11 @@ public class DocService {
         SaveContent defaultSaveContent;
         try {
             defaultSaveContent = createDefaultSaveContent();
-        } catch (MongoTimeoutException | DataAccessResourceFailureException e) {
+        } catch (DataAccessException e) {
             log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
+            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
+        } catch (Exception e) {
+            log.error("DefaultSaveContent Mongo 알 수 없는 오류 - {}", e.getMessage(), e);
             throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
         }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -42,7 +42,7 @@ public class DocService {
     @Value("${default.branch}")
     private String defaultBranchName;
 
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public DocCreateResponse create(DocTitleRequest request, Long userId) {
 
         User user = getUserOrThrow(userId);
@@ -50,7 +50,14 @@ public class DocService {
         String title = request.title();
         checkTitleDuplicate(userId, title);
 
-        //Mongo 저장을 맨처음에 진행하여 실패시 예외 발생으로 인한 종료
+        Doc doc = createDoc(user, title);
+        Branch defaultBranch = createDefaultBranch(doc);
+
+        Save defaultSave = Save.builder()
+                .branch(defaultBranch)
+                .build();
+
+        //Mongo 저장을 RDB 저장 이 후에 진행하여 실패시 예외 발생으로 인한 종료
         SaveContent defaultSaveContent;
         try {
             defaultSaveContent = createDefaultSaveContent();
@@ -59,27 +66,9 @@ public class DocService {
             throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
         }
 
-        try {
-            Doc doc = createDoc(user, title);
-            Branch defaultBranch = createDefaultBranch(doc);
-            createDefaultSave(defaultBranch, defaultSaveContent);
-            return DocMapper.toCreateResponse(doc);
-        } catch (Exception e) {
-            rollbackMongo(defaultSaveContent);
-            log.error("RDB 트랜잭션 중 예외 발생 - {}", e.getMessage(), e);
-            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
-        }
-
-    }
-
-    private void rollbackMongo(SaveContent defaultSaveContent) {
-        try {
-            saveContentRepository.deleteById(defaultSaveContent.getId());
-            log.info("Mongo 롤백 성공: {}", defaultSaveContent.getId());
-        } catch (Exception e) {
-            log.error("DefaultSaveContent Mongo 롤백 실패 - {}", e.getMessage(), e);
-            //추가적인 조치(ex. 재시도, 알림 .. 등등?)
-        }
+        defaultSave.updateSaveMongoId(defaultSaveContent.getId());
+        saveRepository.save(defaultSave);
+        return DocMapper.toCreateResponse(doc);
     }
 
     private Doc createDoc(User user, String title) {
@@ -109,12 +98,6 @@ public class DocService {
         );
     }
 
-    private void createDefaultSave(Branch branch, SaveContent saveContent) {
-        saveRepository.save(Save.builder()
-                .branch(branch)
-                .saveMongoId(saveContent.getId())
-                .build());
-    }
 
     @Transactional(readOnly = true)
     public List<DocListSimpleResponse> getSimpleList(Long userId) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -18,6 +18,7 @@ import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
+import io.ejangs.docsa.global.util.RenewUpdatedAtHelper;
 import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -88,8 +89,8 @@ public class DocService {
                 .name(defaultBranchName)
                 .doc(doc)
                 .build());
-        branchRepository.flush();
         doc.addBranch(branch);
+        RenewUpdatedAtHelper.touch(branch);
         return branch;
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -50,22 +50,36 @@ public class DocService {
         String title = request.title();
         checkTitleDuplicate(userId, title);
 
-        //Mongo 저장을 맨처음에 진행하여 실패시 예외 발생으로 인한 종료 -> 유사 트랜잭션
+        //Mongo 저장을 맨처음에 진행하여 실패시 예외 발생으로 인한 종료
         SaveContent defaultSaveContent;
         try {
             defaultSaveContent = createDefaultSaveContent();
         } catch (MongoTimeoutException | DataAccessResourceFailureException e) {
-            log.error("DefaultSaveContent: Mongo 저장 실패 원인 - {}", e.getMessage());
+            log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
             throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
         }
 
-        Doc doc = createDoc(user, title);
+        try {
+            Doc doc = createDoc(user, title);
+            Branch defaultBranch = createDefaultBranch(doc);
+            createDefaultSave(defaultBranch, defaultSaveContent);
+            return DocMapper.toCreateResponse(doc);
+        } catch (Exception e) {
+            rollbackMongo(defaultSaveContent);
+            log.error("RDB 트랜잭션 중 예외 발생 - {}", e.getMessage(), e);
+            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
+        }
 
-        Branch defaultBranch = createDefaultBranch(doc);
+    }
 
-        createDefaultSave(defaultBranch, defaultSaveContent);
-
-        return DocMapper.toCreateResponse(doc);
+    private void rollbackMongo(SaveContent defaultSaveContent) {
+        try {
+            saveContentRepository.deleteById(defaultSaveContent.getId());
+            log.info("Mongo 롤백 성공: {}", defaultSaveContent.getId());
+        } catch (Exception e) {
+            log.error("DefaultSaveContent Mongo 롤백 실패 - {}", e.getMessage(), e);
+            //추가적인 조치(ex. 재시도, 알림 .. 등등?)
+        }
     }
 
     private Doc createDoc(User user, String title) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -58,16 +58,7 @@ public class DocService {
                 .build();
 
         //Mongo 저장을 RDB 저장 이 후에 진행하여 실패시 예외 발생으로 인한 종료
-        SaveContent defaultSaveContent;
-        try {
-            defaultSaveContent = createDefaultSaveContent();
-        } catch (DataAccessException e) {
-            log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
-            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
-        } catch (Exception e) {
-            log.error("DefaultSaveContent Mongo 알 수 없는 오류 - {}", e.getMessage(), e);
-            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
-        }
+        SaveContent defaultSaveContent = createDefaultSaveContent();
 
         defaultSave.updateSaveMongoId(defaultSaveContent.getId());
         saveRepository.save(defaultSave);
@@ -95,11 +86,20 @@ public class DocService {
     }
 
     private SaveContent createDefaultSaveContent() {
-        return saveContentRepository.save(
-                SaveContent.builder()
-                        .content(new HashMap<>())
-                        .build()
-        );
+
+        try {
+            return saveContentRepository.save(
+                    SaveContent.builder()
+                            .content(new HashMap<>())
+                            .build()
+            );
+        } catch (DataAccessException e) {
+            log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
+            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
+        } catch (Exception e) {
+            log.error("DefaultSaveContent Mongo 알 수 없는 오류 - {}", e.getMessage(), e);
+            throw new CustomException(DocErrorCode.FAIL_CREATE_DOCUMENT);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
@@ -58,5 +58,6 @@ public class Doc extends BaseEntity {
 
     public void addBranch(Branch branch) {
         this.branches.add(branch);
+        this.updatedAt = branch.getUpdatedAt();
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
@@ -1,7 +1,9 @@
 package io.ejangs.docsa.domain.doc.entity;
 
+import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,13 +39,17 @@ public class Doc extends BaseEntity {
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "doc", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Branch> branches;
 
     @Builder
     private Doc(String title, User user) {
         this.title = title;
         this.user = user;
+        this.branches = new ArrayList<>();
     }
 
     public void updateTitle(String title) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
@@ -58,6 +58,5 @@ public class Doc extends BaseEntity {
 
     public void addBranch(Branch branch) {
         this.branches.add(branch);
-        this.updatedAt = branch.getUpdatedAt();
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
@@ -46,11 +46,10 @@ public class Doc extends BaseEntity {
     private List<Branch> branches;
 
     @Builder
-    private Doc(String title, User user, Branch branch) {
+    private Doc(String title, User user) {
         this.title = title;
         this.user = user;
         this.branches = new ArrayList<>();
-        this.branches.add(branch);
     }
 
     public void updateTitle(String title) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Doc.java
@@ -46,13 +46,18 @@ public class Doc extends BaseEntity {
     private List<Branch> branches;
 
     @Builder
-    private Doc(String title, User user) {
+    private Doc(String title, User user, Branch branch) {
         this.title = title;
         this.user = user;
         this.branches = new ArrayList<>();
+        this.branches.add(branch);
     }
 
     public void updateTitle(String title) {
         this.title = title;
+    }
+
+    public void addBranch(Branch branch) {
+        this.branches.add(branch);
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
@@ -34,8 +34,12 @@ public class Save extends BaseEntity {
     private Branch branch;
 
     @Builder
-    private Save(Branch branch, String saveMongoId) {
+    private Save(Branch branch) {
         this.branch = branch;
+    }
+
+    public void updateSaveMongoId(String saveMongoId) {
         this.saveMongoId = saveMongoId;
     }
+
 }

--- a/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -35,7 +34,8 @@ public class Save extends BaseEntity {
     private Branch branch;
 
     @Builder
-    private Save(Branch branch) {
+    private Save(Branch branch, String saveMongoId) {
         this.branch = branch;
+        this.saveMongoId = saveMongoId;
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/user/entity/User.java
+++ b/src/main/java/io/ejangs/docsa/domain/user/entity/User.java
@@ -56,6 +56,6 @@ public class User extends BaseEntity {
 
     public void addDocument(Doc doc) {
         this.docs.add(doc);
-        touch();
+        this.updatedAt = doc.getUpdatedAt();
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/user/entity/User.java
+++ b/src/main/java/io/ejangs/docsa/domain/user/entity/User.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -47,11 +46,6 @@ public class User extends BaseEntity {
         this.password = password;
         this.name = name;
         this.docs = new ArrayList<>();
-    }
-
-    // updateTime 수정
-    public void touch() {
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void addDocument(Doc doc) {

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/DocErrorCode.java
@@ -13,7 +13,9 @@ public enum DocErrorCode implements ErrorCode {
             "JSON_SERIALIZATION_FAILED"),
     COMMIT_NOT_IN_DOCUMENT(HttpStatus.BAD_REQUEST, "커밋이 해당 문서에 속해있지 않습니다",
             "COMMIT_NOT_IN_DOCUMENT"),
-    TITLE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 제목입니다.", "TITLE_DUPLICATION");
+    TITLE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 제목입니다.", "TITLE_DUPLICATION"),
+    FAIL_CREATE_DOCUMENT(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 인해 문서 생성에 실패했습니다.",
+            "FAIL_CREATE_DOCUMENT");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,6 @@ spring:
 
 auth:
   signup-code-cache-name: signupCodeCache
+
+default:
+  branch: main

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -28,6 +28,7 @@ import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,11 @@ public class DocServiceIntegrationTests {
 
     @Value("${default.branch}")
     private String defaultBranchName;
+
+    @AfterEach
+    void cleanup() {
+        saveContentRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("문서 생성 시 문서, 브랜치, 세이브, 세이브컨텐츠가 모두 정상 저장된다")
@@ -136,6 +142,40 @@ public class DocServiceIntegrationTests {
             assertThat(docRepository.findAll()).isEmpty();
             assertThat(branchRepository.findAll()).isEmpty();
             assertThat(saveRepository.findAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("RDB 트랜잭션 실패 케이스")
+    class RdbFailureTest {
+
+        @Autowired
+        private DocService docService;
+        @Autowired
+        private UserRepository userRepository;
+        @Autowired
+        private SaveContentRepository saveContentRepository;
+
+        @MockitoBean
+        private DocRepository docRepository; // 트랜잭션 도중 예외 유도용
+
+        @Test
+        @DisplayName("RDB 트랜잭션 중 예외 발생 시 Mongo SaveContent가 롤백된다")
+        void rollback_mongo_when_rdb_transaction_fails() {
+            // given
+            User user = userRepository.save(DocTestUtils.createUser());
+            DocTitleRequest request = new DocTitleRequest("트랜잭션 실패");
+
+            when(docRepository.save(any()))
+                    .thenThrow(new RuntimeException("RDB 저장 실패"));
+
+            // when
+            assertThatThrownBy(() -> docService.create(request, user.getId()))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining(DocErrorCode.FAIL_CREATE_DOCUMENT.getMessage());
+
+            // then
+            assertThat(saveContentRepository.findAll()).isEmpty();
         }
     }
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -25,7 +25,6 @@ import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @SpringBootTest
@@ -91,14 +92,14 @@ public class DocServiceIntegrationTests {
         // then: 브랜치 저장 검증
         List<Branch> branches = branchRepository.findAll();
         assertThat(branches).hasSize(1);
-        Branch branch = branches.get(0);
+        Branch branch = branches.getFirst();
         assertThat(branch.getName()).isEqualTo(defaultBranchName);
         assertThat(branch.getDoc().getId()).isEqualTo(savedDoc.getId());
 
         // then: Save(RDB) 저장 검증
         List<Save> saves = saveRepository.findAll();
         assertThat(saves).hasSize(1);
-        Save save = saves.get(0);
+        Save save = saves.getFirst();
         assertThat(save.getBranch().getId()).isEqualTo(branch.getId());
 
         // then: SaveContent(MongoDB) 저장 검증
@@ -128,7 +129,9 @@ public class DocServiceIntegrationTests {
 
         @Test
         @DisplayName("Mongo 저장 실패 시 문서 생성 트랜잭션이 중단된다")
-        void fail_when_mongo_save_fails() {
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+            // findAll이 같은 트랜잭션 안에서 수행 되면 rollback 되기 전 상태를 그대로 읽을 수 있음
+        void MongoFailRdbTransaction() {
             User user = userRepository.save(DocTestUtils.createUser());
             DocTitleRequest request = new DocTitleRequest("Mongo 실패 케이스");
 
@@ -142,40 +145,6 @@ public class DocServiceIntegrationTests {
             assertThat(docRepository.findAll()).isEmpty();
             assertThat(branchRepository.findAll()).isEmpty();
             assertThat(saveRepository.findAll()).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("RDB 트랜잭션 실패 케이스")
-    class RdbFailureTest {
-
-        @Autowired
-        private DocService docService;
-        @Autowired
-        private UserRepository userRepository;
-        @Autowired
-        private SaveContentRepository saveContentRepository;
-
-        @MockitoBean
-        private DocRepository docRepository; // 트랜잭션 도중 예외 유도용
-
-        @Test
-        @DisplayName("RDB 트랜잭션 중 예외 발생 시 Mongo SaveContent가 롤백된다")
-        void rollback_mongo_when_rdb_transaction_fails() {
-            // given
-            User user = userRepository.save(DocTestUtils.createUser());
-            DocTitleRequest request = new DocTitleRequest("트랜잭션 실패");
-
-            when(docRepository.save(any()))
-                    .thenThrow(new RuntimeException("RDB 저장 실패"));
-
-            // when
-            assertThatThrownBy(() -> docService.create(request, user.getId()))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining(DocErrorCode.FAIL_CREATE_DOCUMENT.getMessage());
-
-            // then
-            assertThat(saveContentRepository.findAll()).isEmpty();
         }
     }
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -1,22 +1,34 @@
 package io.ejangs.docsa.domain.doc.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
+import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dto.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.util.DocTestUtils;
+import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
+import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
+import io.ejangs.docsa.domain.save.document.SaveContent;
+import io.ejangs.docsa.domain.save.entity.Save;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
 
@@ -33,21 +45,70 @@ public class DocServiceIntegrationTests {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private BranchRepository branchRepository;
+
+    @Autowired
+    private SaveRepository saveRepository;
+
+    @Autowired
+    private SaveContentRepository saveContentRepository;
+
+    @Value("${default.branch}")
+    private String defaultBranchName;
+
     @Test
-    @DisplayName("문서 저장 성공 테스트")
+    @DisplayName("문서 생성 시 문서, 브랜치, 세이브, 세이브컨텐츠가 모두 정상 저장된다")
     void documentCreateSuccess() throws Exception {
-        // given
+        // given: 유저 생성 및 저장
         User user = userRepository.save(DocTestUtils.createUser());
 
-        DocTitleRequest request = new DocTitleRequest("테스트 문서");
+        String title = "첫 문서 신난다!";
+        DocTitleRequest request = new DocTitleRequest(title);
 
-        // when
+        // when: 문서 생성 요청
         DocCreateResponse response = docService.create(request, user.getId());
 
-        // then
-        Doc saved = docRepository.findById(response.id()).orElseThrow();
-        assertEquals("테스트 문서", saved.getTitle());
-        assertEquals(user.getId(), saved.getUser().getId()); // 유저 연결까지 확인
+        // then: 문서 저장 검증
+        Doc savedDoc = docRepository.findById(response.id())
+                .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
+
+        assertThat(savedDoc.getTitle()).isEqualTo(title);
+        assertThat(savedDoc.getUser().getId()).isEqualTo(user.getId());
+        assertThat(response.id()).isEqualTo(savedDoc.getId());
+
+        // then: 브랜치 저장 검증
+        List<Branch> branches = branchRepository.findAll();
+        assertThat(branches).hasSize(1);
+        Branch branch = branches.get(0);
+        assertThat(branch.getName()).isEqualTo(defaultBranchName);
+        assertThat(branch.getDoc().getId()).isEqualTo(savedDoc.getId());
+
+        // then: Save(RDB) 저장 검증
+        List<Save> saves = saveRepository.findAll();
+        assertThat(saves).hasSize(1);
+        Save save = saves.get(0);
+        assertThat(save.getBranch().getId()).isEqualTo(branch.getId());
+
+        // then: SaveContent(MongoDB) 저장 검증
+        String mongoId = save.getSaveMongoId();
+        Optional<SaveContent> content = saveContentRepository.findById(mongoId);
+        assertThat(content).isPresent();
+        assertThat(content.get().getContent()).isEmpty(); // 빈 JSON 확인
+    }
+
+    @Test
+    @DisplayName("중복된 제목으로 문서를 생성할 경우 예외가 발생한다")
+    void documentCreateFailByDuplicateTitle() {
+        // given
+        User user = userRepository.save(DocTestUtils.createUser());
+        String title = "중복 제목 테스트";
+        docService.create(new DocTitleRequest(title), user.getId()); // 첫 번째 저장
+
+        // when & then
+        assertThatThrownBy(() -> docService.create(new DocTitleRequest(title), user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("이미 사용중인 제목입니다.");
     }
 
     @Test

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import com.mongodb.MongoTimeoutException;
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.app.DocService;
@@ -26,10 +29,12 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 
 @SpringBootTest
@@ -95,6 +100,43 @@ public class DocServiceIntegrationTests {
         Optional<SaveContent> content = saveContentRepository.findById(mongoId);
         assertThat(content).isPresent();
         assertThat(content.get().getContent()).isEmpty(); // 빈 JSON 확인
+    }
+
+    @Nested
+    @DisplayName("Mongo 실패 케이스")
+    class MongoFailureTest {
+
+        @Autowired
+        private DocService docService;
+        @Autowired
+        private UserRepository userRepository;
+        @Autowired
+        private DocRepository docRepository;
+        @Autowired
+        private BranchRepository branchRepository;
+        @Autowired
+        private SaveRepository saveRepository;
+
+        @MockitoBean
+        private SaveContentRepository saveContentRepository;
+
+        @Test
+        @DisplayName("Mongo 저장 실패 시 문서 생성 트랜잭션이 중단된다")
+        void fail_when_mongo_save_fails() {
+            User user = userRepository.save(DocTestUtils.createUser());
+            DocTitleRequest request = new DocTitleRequest("Mongo 실패 케이스");
+
+            when(saveContentRepository.save(any()))
+                    .thenThrow(new MongoTimeoutException("Mongo 연결 실패"));
+
+            assertThatThrownBy(() -> docService.create(request, user.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(DocErrorCode.FAIL_CREATE_DOCUMENT.getMessage());
+
+            assertThat(docRepository.findAll()).isEmpty();
+            assertThat(branchRepository.findAll()).isEmpty();
+            assertThat(saveRepository.findAll()).isEmpty();
+        }
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,10 @@ spring:
     console:
       enabled: true
 
+  data:
+    mongodb:
+      uri: ${MONGO_URI}
+
   mail:
     host: smtp.gmail.com
     port: 587
@@ -32,3 +36,6 @@ spring:
 
 auth:
   signup-code-cache-name: signupCodeCache
+
+default:
+  branch: main


### PR DESCRIPTION
## 🛰️ Issue Number
- #34 

## 🪐 작업 내용
문서 생성 시 브랜치와 저장이 생성됩니다.

논리적인 순서로 생성하여 각 연관관계에 넣어주었습니다.

또한 Save RDB와 SaveContent Mongo의 트랜잭션에 대해서 생각하다가
SaveContent를 문서 생성 로직 맨 처음에 위치시켜서 MongoDB의 저장이 실패하면 예외를 터트려서 전체 문서 생성 과정을 중단 시키는 식으로 나름 유사 트랜잭션을 구현했습니다.

다양한 의견 환영입니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?