### PR TITLE
Feat:  일괄 updatedAt 갱신 메서드

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/util/RenewUpdatedAtHelper.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/util/RenewUpdatedAtHelper.java
@@ -1,0 +1,32 @@
+package io.ejangs.docsa.domain.branch.util;
+
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.save.entity.Save;
+
+public class RenewUpdatedAtHelper {
+
+    // 브랜치 변경감지시 브랜치-문서 갱신
+    public static void touch(Branch branch) {
+        branch.updateTimestamp();
+        if (branch.getDoc() != null) {
+            branch.getDoc().updateTimestamp();
+        }
+    }
+
+    // 저장 변경감지시 저장-브랜치-문서 갱신
+    public static void touch(Save save) {
+        save.updateTimestamp();
+        if (save.getBranch() != null) {
+            touch(save.getBranch());
+        }
+    }
+
+    // 기록 변경감지시 기록-브랜치-문서 갱신
+    public static void touch(Commit commit) {
+        commit.updateTimestamp();
+        if (commit.getBranch() != null) {
+            touch(commit.getBranch());
+        }
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/common/BaseEntity.java
+++ b/src/main/java/io/ejangs/docsa/global/common/BaseEntity.java
@@ -23,4 +23,9 @@ public abstract class BaseEntity {
     @Column(name = "updated_at")
     @LastModifiedDate
     protected LocalDateTime updatedAt;
+
+    public void updateTimestamp() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/io/ejangs/docsa/global/util/RenewUpdatedAtHelper.java
+++ b/src/main/java/io/ejangs/docsa/global/util/RenewUpdatedAtHelper.java
@@ -1,4 +1,4 @@
-package io.ejangs.docsa.domain.branch.util;
+package io.ejangs.docsa.global.util;
 
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.entity.Commit;


### PR DESCRIPTION
## 🛰️ Issue Number
#46 

## 🪐 작업 내용

### RenewUpdatedAtHelper 

> 문서 하위에 소속된 **_기록, 브랜치, 저장_**에 변경사항이 있을 때,
> 다음 3가지를 동시에 갱신하기 위해 사용하는 유틸 메서드입니다.
> 
> 1. 해당 객체의 updatedAt
> 2. 해당 객체가 속한 브랜치의 updatedAt
> 3. 해당 브랜치가 속한 updatedAt

- **global.util** 내에 위치합니다.
- touch()로 오버로드 되어있습니다.


```java
public class RenewUpdatedAtHelper {

    // 브랜치 변경감지시 브랜치-문서 갱신
    public static void touch(Branch branch) {
        branch.updateTimestamp();
        if (branch.getDoc() != null) {
            branch.getDoc().updateTimestamp();
        }
    }

    // 저장 변경감지시 저장-브랜치-문서 갱신
    public static void touch(Save save) {
        save.updateTimestamp();
        if (save.getBranch() != null) {
            touch(save.getBranch());
        }
    }

    // 기록 변경감지시 기록-브랜치-문서 갱신
    public static void touch(Commit commit) {
        commit.updateTimestamp();
        if (commit.getBranch() != null) {
            touch(commit.getBranch());
        }
    }
}
```


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?