### PR TITLE
Feat: 비밀번호 변경 시 인증코드 전송 API

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/auth/api/AuthController.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package io.ejangs.docsa.domain.auth.api;
 
 import io.ejangs.docsa.domain.auth.app.AuthService;
 import io.ejangs.docsa.domain.auth.dto.request.CodeCheckRequest;
+import io.ejangs.docsa.domain.auth.dto.request.PwdResetCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.response.CodeCheckResponse;
 import jakarta.mail.MessagingException;
@@ -25,6 +26,13 @@ public class AuthController {
     public ResponseEntity<Void> sendSignupCode(@Valid @RequestBody SignupCodeRequest request)
             throws MessagingException {
         authService.sendSignupCode(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Void> sendResetPwdCode(@Valid @RequestBody PwdResetCodeRequest request)
+            throws MessagingException {
+        authService.sendResetPwdCode(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/app/AuthService.java
@@ -1,13 +1,15 @@
 package io.ejangs.docsa.domain.auth.app;
 
 import io.ejangs.docsa.domain.auth.dto.request.CodeCheckRequest;
+import io.ejangs.docsa.domain.auth.dto.request.PwdResetCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import io.ejangs.docsa.domain.auth.util.AuthCodeGenerator;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.auth.dto.response.CodeCheckResponse;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import jakarta.mail.MessagingException;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
@@ -22,6 +24,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final MailService mailService;
     private final CacheManager cacheManager;
+    private final AuthCodeGenerator authCodeGenerator;
 
     @Value("${auth.signup-code-cache-name}")
     private String signupCacheName;
@@ -29,15 +32,18 @@ public class AuthService {
     @Value("${auth.passcode-cache-name}")
     private String passcodeCacheName;
 
+    @Value("${auth.pwd-reset-code-cache-name}")
+    private String pwdResetCacheName;
+
     public void sendSignupCode(SignupCodeRequest request) throws MessagingException {
 
         if (userRepository.existsByEmail(request.email())) {
             throw new CustomException(AuthErrorCode.DUPLICATE_EMAIL);
         }
 
-        String code = generateCode();
+        String code = authCodeGenerator.generateVerifyCode();
         cacheManager.getCache(signupCacheName).put(request.email(), code);
-        mailService.sendSignupAuthCode(request.email(), code);
+        mailService.sendCodeMail(request.email(), code);
     }
 
     public CodeCheckResponse checkCode(CodeCheckRequest request) {
@@ -54,40 +60,21 @@ public class AuthService {
             throw new CustomException(AuthErrorCode.INVALID_CODE);
         }
 
-        String passCode = generatePassCode();
+        String passCode = authCodeGenerator.generatePassCode();
         cacheManager.getCache(passcodeCacheName).put(request.email(), passCode);
         cache.evict(request.email());
 
         return new CodeCheckResponse(passCode);
     }
 
-    private String generateCode() {
-        Random random = new Random();
-        StringBuilder key = new StringBuilder();
+    public void sendResetPwdCode(PwdResetCodeRequest request) throws MessagingException {
 
-        for (int i = 0; i < 6; i++) {
-            int index = random.nextInt(2);
-
-            switch (index) {
-                case 0 -> key.append((char) (random.nextInt(26) + 65)); // A-Z
-                case 1 -> key.append(random.nextInt(10)); // 0-9
-            }
+        if (!userRepository.existsByEmail(request.email())) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
-        return key.toString();
-    }
 
-    private String generatePassCode() {
-        Random random = new Random();
-        StringBuilder passCode = new StringBuilder();
-
-        for (int i = 0; i < 8; i++) {
-            int index = random.nextInt(2);
-
-            switch (index) {
-                case 0 -> passCode.append((char) (random.nextInt(26) + 97)); // a-z
-                case 1 -> passCode.append(random.nextInt(10)); // 0-9
-            }
-        }
-        return passCode.toString();
+        String code = authCodeGenerator.generateVerifyCode();
+        cacheManager.getCache(pwdResetCacheName).put(request.email(), code);
+        mailService.sendCodeMail(request.email(), code);
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/auth/app/MailService.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/app/MailService.java
@@ -16,12 +16,12 @@ public class MailService {
 
     private final JavaMailSender javaMailSender;
 
-    public void sendSignupAuthCode(String to, String code) throws MessagingException {
-        MimeMessage message = createSignupCodeMail(to, code);
+    public void sendCodeMail(String to, String code) throws MessagingException {
+        MimeMessage message = createCodeMail(to, code);
         javaMailSender.send(message);
     }
 
-    private MimeMessage createSignupCodeMail(String to, String code) throws MessagingException {
+    private MimeMessage createCodeMail(String to, String code) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
 
         message.setFrom(senderEmail);

--- a/src/main/java/io/ejangs/docsa/domain/auth/dto/request/PwdResetCodeRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/dto/request/PwdResetCodeRequest.java
@@ -1,0 +1,13 @@
+package io.ejangs.docsa.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PwdResetCodeRequest(
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email
+) {
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/auth/util/AuthCodeGenerator.java
+++ b/src/main/java/io/ejangs/docsa/domain/auth/util/AuthCodeGenerator.java
@@ -1,0 +1,36 @@
+package io.ejangs.docsa.domain.auth.util;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class AuthCodeGenerator {
+
+    private static final SecureRandom random = new SecureRandom();
+
+    public String generateVerifyCode() {
+        return generateCode(6, true);
+    }
+
+    public String generatePassCode() {
+        return generateCode(8, false);
+    }
+
+    private String generateCode(int length, boolean useUpperCase) {
+        StringBuilder code = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            boolean isLetter = random.nextBoolean();
+
+            if (isLetter) {
+                char baseChar = useUpperCase ? 'A' : 'a';
+                code.append((char) (random.nextInt(26) + baseChar));
+            } else {
+                code.append(random.nextInt(10));
+            }
+        }
+
+        return code.toString();
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/config/CacheConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/CacheConfig.java
@@ -14,7 +14,8 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("signupCodeCache", "passCodeCache");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("signupCodeCache",
+                "passCodeCache", "pwdResetCodeCache");
         cacheManager.setCaffeine(
                 Caffeine.newBuilder()
                         .expireAfterWrite(3, TimeUnit.MINUTES)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,14 @@ spring:
     cache-names:
       - signupCodeCache
       - passCodeCache
+      - pwdResetCodeCache
     caffeine:
       spec: maximumSize=10000, expireAfterWrite=3m
 
 auth:
   signup-code-cache-name: signupCodeCache
   passcode-cache-name: passCodeCache
+  pwd-reset-code-cache-name: pwdResetCodeCache
 
 default:
   branch: main

--- a/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
@@ -15,10 +15,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ejangs.docsa.domain.auth.app.AuthService;
 import io.ejangs.docsa.domain.auth.dto.request.CodeCheckRequest;
+import io.ejangs.docsa.domain.auth.dto.request.PwdResetCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.response.CodeCheckResponse;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -204,5 +206,45 @@ class AuthControllerTest {
                 .andDo(print());
 
         verify(authService, never()).checkCode(any());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 시 인증코드 전송 요청 성공")
+    void sendPwdResetCode_Success() throws Exception {
+        // given
+        PwdResetCodeRequest request = new PwdResetCodeRequest("test@example.com");
+
+        doNothing().when(authService).sendResetPwdCode(request);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""))
+                .andDo(print());
+
+        verify(authService).sendResetPwdCode(request);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 시 존재하지 않는 사용자 예외 발생")
+    void sendResetPwdCode_UserNotFound() throws Exception {
+        // given
+        PwdResetCodeRequest request = new PwdResetCodeRequest("test@example.com");
+
+        doThrow(new CustomException(UserErrorCode.USER_NOT_FOUND))
+                .when(authService).sendResetPwdCode(any(PwdResetCodeRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/code/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("USER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."))
+                .andDo(print());
+
+        verify(authService).sendResetPwdCode(any(PwdResetCodeRequest.class));
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/auth/app/AuthServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/app/AuthServiceTest.java
@@ -11,11 +11,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.ejangs.docsa.domain.auth.dto.request.CodeCheckRequest;
+import io.ejangs.docsa.domain.auth.dto.request.PwdResetCodeRequest;
 import io.ejangs.docsa.domain.auth.dto.request.SignupCodeRequest;
+import io.ejangs.docsa.domain.auth.util.AuthCodeGenerator;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.auth.dto.response.CodeCheckResponse;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import jakarta.mail.MessagingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,77 +49,93 @@ class AuthServiceTest {
     @Mock
     private Cache passCodeCache;
 
+    @Mock
+    private Cache pwdResetCodeCache;
+
+    @Mock
+    private AuthCodeGenerator authCodeGenerator;
+
     @InjectMocks
     private AuthService authService;
 
-    private SignupCodeRequest request;
+    private SignupCodeRequest signupRequest;
+    private PwdResetCodeRequest pwdResetRequest;
 
     @BeforeEach
     void setUp() {
-        request = new SignupCodeRequest("test@example.com");
+        signupRequest = new SignupCodeRequest("test@example.com");
+        pwdResetRequest = new PwdResetCodeRequest("test@example.com");
+
         ReflectionTestUtils.setField(authService, "signupCacheName", "signupCodeCache");
         ReflectionTestUtils.setField(authService, "passcodeCacheName", "passCodeCache");
+        ReflectionTestUtils.setField(authService, "pwdResetCacheName", "pwdResetCodeCache");
+
         lenient().when(cacheManager.getCache("signupCodeCache")).thenReturn(signupCodeCache);
         lenient().when(cacheManager.getCache("passcodeCache")).thenReturn(passCodeCache);
+        lenient().when(cacheManager.getCache("pwdResetCodeCache")).thenReturn(pwdResetCodeCache);
     }
 
     @Test
-    @DisplayName("정상적인 인증코드 전송")
+    @DisplayName("회원가입 - 정상적인 인증코드 전송")
     void sendSignupCode_Success() throws MessagingException {
         // given
-        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userRepository.existsByEmail(signupRequest.email())).thenReturn(false);
+        when(authCodeGenerator.generateVerifyCode()).thenReturn("ABC123");
 
         // when
-        authService.sendSignupCode(request);
+        authService.sendSignupCode(signupRequest);
 
         // then
-        verify(userRepository).existsByEmail(request.email());
-        verify(signupCodeCache).put(eq(request.email()), any(String.class));
-        verify(mailService).sendSignupAuthCode(eq(request.email()), any(String.class));
+        verify(signupCodeCache).put(eq(signupRequest.email()), eq("ABC123"));
+        verify(mailService).sendCodeMail(eq(signupRequest.email()), eq("ABC123"));
     }
 
     @Test
-    @DisplayName("이미 가입된 이메일로 요청 시 예외 발생")
+    @DisplayName("회원가입 - 이미 가입된 이메일로 요청 시 예외 발생")
     void sendSignupCode_DuplicateEmail() throws MessagingException {
         // given
-        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+        when(userRepository.existsByEmail(signupRequest.email())).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> authService.sendSignupCode(request))
+        assertThatThrownBy(() -> authService.sendSignupCode(signupRequest))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.DUPLICATE_EMAIL);
 
-        verify(userRepository).existsByEmail(request.email());
+        verify(userRepository).existsByEmail(signupRequest.email());
         verify(signupCodeCache, never()).put(any(), any());
-        verify(mailService, never()).sendSignupAuthCode(any(), any());
+        verify(mailService, never()).sendCodeMail(any(), any());
     }
 
     @Test
     @DisplayName("메일 전송 실패 시 예외 발생")
     void sendSignupCode_MailSendingFailed() throws MessagingException {
         // given
-        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userRepository.existsByEmail(signupRequest.email())).thenReturn(false);
+        when(authCodeGenerator.generateVerifyCode()).thenReturn("MAIL01");
+
         doThrow(new MessagingException("Mail server error"))
-                .when(mailService).sendSignupAuthCode(any(), any());
+                .when(mailService).sendCodeMail(signupRequest.email(), "MAIL01");
 
         // when & then
-        assertThatThrownBy(() -> authService.sendSignupCode(request))
+        assertThatThrownBy(() -> authService.sendSignupCode(signupRequest))
                 .isInstanceOf(MessagingException.class)
                 .hasMessage("Mail server error");
 
-        verify(signupCodeCache).put(eq(request.email()), any(String.class));
-        verify(mailService).sendSignupAuthCode(eq(request.email()), any(String.class));
+        verify(signupCodeCache).put(signupRequest.email(), "MAIL01");
+        verify(mailService).sendCodeMail(signupRequest.email(), "MAIL01");
     }
 
     @Test
-    @DisplayName("정상적인 인증코드 검증 성공")
+    @DisplayName("정상적인 인증코드 검증")
     void checkCode_Success() {
         // given
-        String email = request.email();
+        String email = signupRequest.email();
         String code = "ABC123";
+        String passCode = "PASS5678";
 
         when(signupCodeCache.get(email)).thenReturn(() -> code);
         when(cacheManager.getCache("passCodeCache")).thenReturn(passCodeCache);
+        when(authCodeGenerator.generatePassCode()).thenReturn(passCode);
 
         CodeCheckRequest checkRequest = new CodeCheckRequest(email, code);
 
@@ -125,8 +144,8 @@ class AuthServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.passCode()).hasSize(8);
-        verify(passCodeCache).put(eq(email), any(String.class));
+        assertThat(response.passCode()).isEqualTo(passCode);
+        verify(passCodeCache).put(email, passCode);
         verify(signupCodeCache).evict(email);
     }
 
@@ -134,7 +153,7 @@ class AuthServiceTest {
     @DisplayName("인증코드 만료된 경우 예외 발생")
     void checkCode_CodeExpired() {
         // given
-        String email = request.email();
+        String email = signupRequest.email();
         when(signupCodeCache.get(email)).thenReturn(null); // 캐시에 없음
 
         CodeCheckRequest checkRequest = new CodeCheckRequest(email, "ANYCODE");
@@ -151,7 +170,7 @@ class AuthServiceTest {
     @DisplayName("인증코드 불일치 시 예외 발생")
     void checkCode_InvalidCode() {
         // given
-        String email = request.email();
+        String email = signupRequest.email();
         String realCode = "REAL12";
         String wrongCode = "WRONG9";
 
@@ -165,5 +184,35 @@ class AuthServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.INVALID_CODE);
 
         verify(signupCodeCache, never()).evict(any());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 정상적인 인증코드 전송")
+    void sendResetPwdCode_Success() throws MessagingException {
+        // given
+        when(userRepository.existsByEmail(pwdResetRequest.email())).thenReturn(true);
+        when(authCodeGenerator.generateVerifyCode()).thenReturn("RESET1");
+
+        // when
+        authService.sendResetPwdCode(pwdResetRequest);
+
+        // then
+        verify(pwdResetCodeCache).put(eq(pwdResetRequest.email()), eq("RESET1"));
+        verify(mailService).sendCodeMail(eq(pwdResetRequest.email()), eq("RESET1"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 존재하지 않는 사용자인 경우 예외 발생")
+    void sendResetPwdCode_UserNotFound() throws MessagingException {
+        // given
+        when(userRepository.existsByEmail(pwdResetRequest.email())).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.sendResetPwdCode(pwdResetRequest))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+        verify(pwdResetCodeCache, never()).put(any(), any());
+        verify(mailService, never()).sendCodeMail(any(), any());
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #59 

## 🪐 작업 내용
- 비밀번호 변경 시 필요한 인증코드 전송 api 구현했습니다.
- 전체적으로는 회원가입 시 인증코드 보내는 과정과 동일하며, 인증코드 생성 로직을 `AuthCodeGenerator`로 분리하고 메일 보내는 메서드들도 재사용하기 위해 이름을 수정하였습니다.
    - 인증 코드는 알파벳 대문자와 숫자로 구성된 6자리 난수로 만들었습니다.
    - 인증 코드는 로컬 메모리 기반의 Caffeine Cache에 저장하도록 하였고 3분 후 만료되어 제거되도록 설정하였습니다.


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?