### PR TITLE
Feat: 병합하기 API

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/block/app/BlockService.java
+++ b/src/main/java/io/ejangs/docsa/domain/block/app/BlockService.java
@@ -26,4 +26,8 @@ public class BlockService {
     public List<Block> getAllById(List<String> blockIds) {
         return blockRepository.findAllById(blockIds);
     }
+
+    public void deleteBlock(String blockId) {
+        blockRepository.deleteById(blockId);
+    }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -183,6 +183,9 @@ public class BranchService {
             throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
     }
 
+    public Branch saveBranch(Branch branch) {
+        return branchRepository.save(branch);
+    }
 }
 
 

--- a/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
@@ -52,7 +52,7 @@ public class Branch extends BaseEntity {
     @JoinColumn(name = "leaf_commit_id")
     private Commit leafCommit;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "branch", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Commit> commits;
 
     @OneToOne(mappedBy = "branch", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -96,7 +96,8 @@ public class Branch extends BaseEntity {
             commit.setBranch(this);
         }
     }
-    public void updateName(String name){
+
+    public void updateName(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -2,6 +2,7 @@ package io.ejangs.docsa.domain.commit.api;
 
 import io.ejangs.docsa.domain.commit.app.CommitService;
 import io.ejangs.docsa.domain.commit.dto.request.CreateCommitRequest;
+import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
@@ -48,5 +49,14 @@ public class CommitController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(commitService.compareCommitForMerge(docId, baseId, targetId));
+    }
+
+    @PostMapping("/api/document/{docId}/merge")
+    public ResponseEntity<CreateCommitResponse> mergeCommit(
+            @PathVariable("docId") Long docId,
+            @RequestBody @Valid MergeCommitRequest mergeRequest) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commitService.mergeCommit(docId, mergeRequest));
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -3,12 +3,15 @@ package io.ejangs.docsa.domain.commit.app;
 import com.mongodb.MongoException;
 import io.ejangs.docsa.domain.block.app.BlockService;
 import io.ejangs.docsa.domain.block.document.Block;
+import io.ejangs.docsa.domain.block.dto.response.BlockDto;
 import io.ejangs.docsa.domain.branch.app.BranchService;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dao.mongodb.CommitBlockSequenceRepository;
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.document.CommitBlockSequence;
+import io.ejangs.docsa.domain.commit.dto.CommitMongoIdsDto;
 import io.ejangs.docsa.domain.commit.dto.request.CreateCommitRequest;
+import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
@@ -133,6 +136,107 @@ public class CommitService {
         List<Map<String, Object>> targetContent = getWholeContent(targetId);
 
         return new CompareMergeCommitResponse(baseContent, targetContent);
+    }
+
+    public CreateCommitResponse mergeCommit(Long docId, MergeCommitRequest mergeRequest) {
+        /**
+         * Block을 저장하고
+         * CommitSequence를 저장하고
+         *
+         * Commit을 생성하고
+         * Commit에 CommitSequence의 _id를 저장하고
+         * 간선을 2개 저장하고
+         * baseBranch의 leaf를 업데이트
+         */
+        CommitMongoIdsDto commitMongoIds = null;
+        try {
+            // 문서가 존재하는지 검사
+            Doc doc = docService.getById(docId);
+            // 브랜치가 존재하는지 검사
+            Branch baseBranch = branchService.getById(mergeRequest.baseBranchId());
+            Branch targetBranch = branchService.getById(mergeRequest.targetBranchId());
+
+            // Block과 Cbs를 저장
+            commitMongoIds = saveBlockAndSequence(mergeRequest.content());
+
+            // Commit을 저장
+            Commit saveMergeCommit = saveMergeCommit(doc, baseBranch, targetBranch,
+                    mergeRequest, commitMongoIds.cbsId());
+
+            return CommitMapper.toCreateCommitResponse(saveMergeCommit);
+        } catch (Exception e) {
+            if (commitMongoIds != null) {
+                /**
+                 * 롤백 시도
+                 * ToDo : MongoDeleteHandler를 적용시 변경될 예정
+                 * eventPublisher.publishEvent(docDeleteMongoIds)?
+                 */
+                rollbackMongoTransaction(commitMongoIds);
+            }
+            if (e instanceof CustomException) {
+                throw (CustomException) e;
+            }
+            log.error("Create Commit 알 수 없는 오류 - {}", e.getMessage(), e);
+            throw new CustomException(CommitErrorCode.FAIL_CREATE_COMMIT);
+        }
+    }
+
+    @Transactional(transactionManager = "jpaTransactionManager")
+    public Commit saveMergeCommit(Doc doc, Branch baseBranch, Branch targetBranch,
+            MergeCommitRequest request, String commitMongoId) {
+
+        Commit commit = CommitMapper.toEntity(baseBranch, request);
+        commit.initializeCommitMongoId(commitMongoId);
+        Commit savedCommit = commitRepository.save(commit);
+        commitRepository.flush();
+
+        baseBranch.addCommit(savedCommit);
+
+        Commit baseCommit = getLeafCommit(baseBranch);
+        Commit targetCommit = getLeafCommit(targetBranch);
+
+        Edge edge1 = EdgeMapper.toEntity(doc, baseCommit, savedCommit);
+        Edge edge2 = EdgeMapper.toEntity(doc, targetCommit, savedCommit);
+        edgeService.saveEdge(edge1);
+        edgeService.saveEdge(edge2);
+
+        baseBranch.updateLeafCommit(savedCommit);
+        branchService.saveBranch(baseBranch);
+
+        return savedCommit;
+    }
+
+    // ToDo: MongoTransactionManager 적용 필요
+    @Transactional(transactionManager = "mongoTransactionManager")
+    public CommitMongoIdsDto saveBlockAndSequence(List<BlockDto> blocks) {
+        List<Block> savedBlocks = blockService.saveBlocks(blocks);
+        List<String> blockSequence = savedBlocks.stream()
+                .map(Block::getId)
+                .toList();
+
+        CommitBlockSequence cbs = CommitBlockSequenceMapper.toEntity(blockSequence);
+        CommitBlockSequence savedCbs = cbsRepository.save(cbs);
+
+        return new CommitMongoIdsDto(savedCbs.getId(), blockSequence);
+    }
+
+    @Transactional(transactionManager = "mongoTransactionManager")
+    public void rollbackMongoTransaction(CommitMongoIdsDto commitMongoIds) {
+        try {
+            // 관련된 Block들도 삭제 (필요한 경우)
+            commitMongoIds.blockIds().forEach(blockService::deleteBlock);
+
+            // CommitBlockSequence 삭제
+            cbsRepository.deleteById(commitMongoIds.cbsId());
+        } catch (Exception e) {
+            log.error("Failed to rollback MongoDB", e);
+            // TODO 롤백 실패 로직 고민 필요
+        }
+    }
+
+    private Commit getLeafCommit(Branch branch) {
+        return Optional.ofNullable(branch.getLeafCommit())
+                .orElseThrow(() -> new CustomException(CommitErrorCode.COMMIT_NOT_FOUND));
     }
 
     private List<Map<String, Object>> getWholeContent(Long commitId) {

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -138,6 +138,7 @@ public class CommitService {
         return new CompareMergeCommitResponse(baseContent, targetContent);
     }
 
+    @Transactional
     public CreateCommitResponse mergeCommit(Long docId, MergeCommitRequest mergeRequest) {
         /**
          * Block을 저장하고
@@ -159,6 +160,9 @@ public class CommitService {
             // Block과 Cbs를 저장
             commitMongoIds = saveBlockAndSequence(mergeRequest.content());
 
+            /**
+             * ToDo: 만약 정상작동하지 않는다면 여기서 이벤트 기반 처리로 넘기는게 나을 수 있을것 같습니다
+             */
             // Commit을 저장
             Commit saveMergeCommit = saveMergeCommit(doc, baseBranch, targetBranch,
                     mergeRequest, commitMongoIds.cbsId());
@@ -181,7 +185,7 @@ public class CommitService {
         }
     }
 
-    @Transactional(transactionManager = "jpaTransactionManager")
+    @Transactional//(transactionManager = "jpaTransactionManager")
     public Commit saveMergeCommit(Doc doc, Branch baseBranch, Branch targetBranch,
             MergeCommitRequest request, String commitMongoId) {
 
@@ -207,7 +211,7 @@ public class CommitService {
     }
 
     // ToDo: MongoTransactionManager 적용 필요
-    @Transactional(transactionManager = "mongoTransactionManager")
+    @Transactional//(transactionManager = "mongoTransactionManager")
     public CommitMongoIdsDto saveBlockAndSequence(List<BlockDto> blocks) {
         List<Block> savedBlocks = blockService.saveBlocks(blocks);
         List<String> blockSequence = savedBlocks.stream()
@@ -220,7 +224,7 @@ public class CommitService {
         return new CommitMongoIdsDto(savedCbs.getId(), blockSequence);
     }
 
-    @Transactional(transactionManager = "mongoTransactionManager")
+    @Transactional//(transactionManager = "mongoTransactionManager")
     public void rollbackMongoTransaction(CommitMongoIdsDto commitMongoIds) {
         try {
             // 관련된 Block들도 삭제 (필요한 경우)

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -154,6 +154,7 @@ public class CommitService {
             // 문서가 존재하는지 검사
             Doc doc = docService.getById(docId);
             // 브랜치가 존재하는지 검사
+            checkBranch(mergeRequest.baseBranchId(), mergeRequest.targetBranchId());
             Branch baseBranch = branchService.getById(mergeRequest.baseBranchId());
             Branch targetBranch = branchService.getById(mergeRequest.targetBranchId());
 
@@ -174,6 +175,12 @@ public class CommitService {
             }
             log.error("Create Commit 알 수 없는 오류 - {}", e.getMessage(), e);
             throw new CustomException(CommitErrorCode.FAIL_CREATE_COMMIT);
+        }
+    }
+
+    private void checkBranch(Long baseBranchId, Long targetBranchId) {
+        if (baseBranchId == null || targetBranchId == null || baseBranchId.equals(targetBranchId)) {
+            throw new CustomException(CommitErrorCode.COMMIT_BAD_REQUEST);
         }
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -160,9 +160,6 @@ public class CommitService {
             // Block과 Cbs를 저장
             commitMongoIds = saveBlockAndSequence(mergeRequest.content());
 
-            /**
-             * ToDo: 만약 정상작동하지 않는다면 여기서 이벤트 기반 처리로 넘기는게 나을 수 있을것 같습니다
-             */
             // Commit을 저장
             Commit saveMergeCommit = saveMergeCommit(doc, baseBranch, targetBranch,
                     mergeRequest, commitMongoIds.cbsId());
@@ -170,11 +167,6 @@ public class CommitService {
             return CommitMapper.toCreateCommitResponse(saveMergeCommit);
         } catch (Exception e) {
             if (commitMongoIds != null) {
-                /**
-                 * 롤백 시도
-                 * ToDo : MongoDeleteHandler를 적용시 변경될 예정
-                 * eventPublisher.publishEvent(docDeleteMongoIds)?
-                 */
                 rollbackMongoTransaction(commitMongoIds);
             }
             if (e instanceof CustomException) {
@@ -185,8 +177,7 @@ public class CommitService {
         }
     }
 
-    @Transactional//(transactionManager = "jpaTransactionManager")
-    public Commit saveMergeCommit(Doc doc, Branch baseBranch, Branch targetBranch,
+    private Commit saveMergeCommit(Doc doc, Branch baseBranch, Branch targetBranch,
             MergeCommitRequest request, String commitMongoId) {
 
         Commit commit = CommitMapper.toEntity(baseBranch, request);
@@ -210,22 +201,27 @@ public class CommitService {
         return savedCommit;
     }
 
-    // ToDo: MongoTransactionManager 적용 필요
-    @Transactional//(transactionManager = "mongoTransactionManager")
-    public CommitMongoIdsDto saveBlockAndSequence(List<BlockDto> blocks) {
-        List<Block> savedBlocks = blockService.saveBlocks(blocks);
-        List<String> blockSequence = savedBlocks.stream()
-                .map(Block::getId)
-                .toList();
+    private CommitMongoIdsDto saveBlockAndSequence(List<BlockDto> blocks) {
+        List<Block> savedBlocks = null;
+        try {
+            savedBlocks = blockService.saveBlocks(blocks);
+            List<String> blockSequence = savedBlocks.stream()
+                    .map(Block::getId)
+                    .toList();
 
-        CommitBlockSequence cbs = CommitBlockSequenceMapper.toEntity(blockSequence);
-        CommitBlockSequence savedCbs = cbsRepository.save(cbs);
+            CommitBlockSequence cbs = CommitBlockSequenceMapper.toEntity(blockSequence);
+            CommitBlockSequence savedCbs = cbsRepository.save(cbs);
 
-        return new CommitMongoIdsDto(savedCbs.getId(), blockSequence);
+            return new CommitMongoIdsDto(savedCbs.getId(), blockSequence);
+        } catch (Exception e) {
+            if (savedBlocks != null) {
+                savedBlocks.forEach(block -> blockService.deleteBlock(block.getId()));
+            }
+            throw new CustomException(CommitErrorCode.FAIL_CREATE_COMMIT);
+        }
     }
 
-    @Transactional//(transactionManager = "mongoTransactionManager")
-    public void rollbackMongoTransaction(CommitMongoIdsDto commitMongoIds) {
+    private void rollbackMongoTransaction(CommitMongoIdsDto commitMongoIds) {
         try {
             // 관련된 Block들도 삭제 (필요한 경우)
             commitMongoIds.blockIds().forEach(blockService::deleteBlock);

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -179,7 +179,8 @@ public class CommitService {
     }
 
     private void checkBranch(Long baseBranchId, Long targetBranchId) {
-        if (baseBranchId == null || targetBranchId == null || baseBranchId.equals(targetBranchId)) {
+        if (baseBranchId == null || targetBranchId == null || baseBranchId < 0 || targetBranchId < 0
+                || baseBranchId.equals(targetBranchId)) {
             throw new CustomException(CommitErrorCode.COMMIT_BAD_REQUEST);
         }
     }

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -204,7 +204,9 @@ public class CommitService {
         edgeService.saveEdge(edge2);
 
         baseBranch.updateLeafCommit(savedCommit);
+        saveService.deleteSaveIfExists(baseBranch.getId());
         RenewUpdatedAtHelper.touch(baseBranch);
+
         branchService.saveBranch(baseBranch);
 
         return savedCommit;

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -204,6 +204,7 @@ public class CommitService {
         edgeService.saveEdge(edge2);
 
         baseBranch.updateLeafCommit(savedCommit);
+        RenewUpdatedAtHelper.touch(baseBranch);
         branchService.saveBranch(baseBranch);
 
         return savedCommit;

--- a/src/main/java/io/ejangs/docsa/domain/commit/dto/CommitMongoIdsDto.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/dto/CommitMongoIdsDto.java
@@ -1,0 +1,10 @@
+package io.ejangs.docsa.domain.commit.dto;
+
+import java.util.List;
+
+public record CommitMongoIdsDto(
+        String cbsId,
+        List<String> blockIds
+) {
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/commit/dto/request/MergeCommitRequest.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/dto/request/MergeCommitRequest.java
@@ -1,0 +1,19 @@
+package io.ejangs.docsa.domain.commit.dto.request;
+
+import io.ejangs.docsa.domain.block.dto.response.BlockDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record MergeCommitRequest(
+        @NotBlank(message = "기록 제목을 입력해주세요.")
+        @Size(min = 1, max = 30, message = "기록 제목은 30자를 초과 할 수 없습니다.")
+        String title,
+        @Size(max = 100, message = "기록에 대한 설명은 100자를 초과 할 수 없습니다.")
+        String description,
+        Long baseBranchId,
+        Long targetBranchId,
+        List<BlockDto> content
+) {
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/commit/util/CommitMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/util/CommitMapper.java
@@ -2,6 +2,7 @@ package io.ejangs.docsa.domain.commit.util;
 
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dto.request.CreateCommitRequest;
+import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 
@@ -20,6 +21,14 @@ public class CommitMapper {
         return Commit.builder()
                 .title(commitRequest.title())
                 .description(commitRequest.description())
+                .branch(branch)
+                .build();
+    }
+
+    public static Commit toEntity(Branch branch, MergeCommitRequest request) {
+        return Commit.builder()
+                .title(request.title())
+                .description(request.description())
                 .branch(branch)
                 .build();
     }

--- a/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/EdgeRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/EdgeRepository.java
@@ -1,8 +1,10 @@
 package io.ejangs.docsa.domain.doc.dao.mysql;
 
 import io.ejangs.docsa.domain.doc.entity.Edge;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EdgeRepository extends JpaRepository<Edge, Integer> {
 
+    List<Edge> findByNextCommitId(Long id);
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/entity/Edge.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/entity/Edge.java
@@ -29,11 +29,11 @@ public class Edge {
     @JoinColumn(name = "document_id", nullable = false)
     private Doc doc;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "prev_commit_id", nullable = false)
     private Commit prevCommit;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_commit_id", nullable = false)
     private Commit nextCommit;
 

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
@@ -23,7 +23,7 @@ import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.commit.util.CommitBlockSequenceMapper;
 import io.ejangs.docsa.domain.commit.util.CommitMapper;
-import io.ejangs.docsa.domain.commit.util.CommitTestUtils;
+import io.ejangs.docsa.domain.commit.util.CommitMockTestUtils;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.app.EdgeService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -95,45 +95,45 @@ class CommitServiceMockTest {
                 "Test commit message",
                 "",
                 1L,
-                List.of(CommitTestUtils.createBlockRequest("block1"),
-                        CommitTestUtils.createBlockRequest("block2")),
+                List.of(CommitMockTestUtils.createBlockRequest("block1"),
+                        CommitMockTestUtils.createBlockRequest("block2")),
                 List.of("block1", "block2")
         );
 
         // User 생성
-        user = CommitTestUtils.createUser();
+        user = CommitMockTestUtils.createUser();
 
         // Doc 생성
-        doc = CommitTestUtils.createDoc(user);
+        doc = CommitMockTestUtils.createDoc(user);
 
         // Branch 생성
-        branch = CommitTestUtils.createBranch(doc, baseCommit);
+        branch = CommitMockTestUtils.createBranch(doc, baseCommit);
 
         // Base commit 생성
-        baseCommit = CommitTestUtils.createBaseCommit(branch);
+        baseCommit = CommitMockTestUtils.createBaseCommit(branch);
         baseCommit.setBranch(branch);
 
         // Blocks 생성
         savedBlocks = List.of(
-                CommitTestUtils.createBlock("block1"),
-                CommitTestUtils.createBlock("block2")
+                CommitMockTestUtils.createBlock("block1"),
+                CommitMockTestUtils.createBlock("block2")
         );
 
         baseCommitBlocks = List.of(
-                CommitTestUtils.createBlock("baseBlock1")
+                CommitMockTestUtils.createBlock("baseBlock1")
         );
 
         // CommitBlockSequence 생성
-        savedCbs = CommitTestUtils.createCommitBlockSequence();
+        savedCbs = CommitMockTestUtils.createCommitBlockSequence();
 
         // Commit 생성
-        savedCommit = CommitTestUtils.createMockCommit(branch, 2L);
+        savedCommit = CommitMockTestUtils.createMockCommit(branch, 2L);
 
         // Expected response 생성
         expectedResponse = new CreateCommitResponse(1L);
 
         // edge 생성
-        edge = CommitTestUtils.createEdge(doc, baseCommit, savedCommit);
+        edge = CommitMockTestUtils.createEdge(doc, baseCommit, savedCommit);
     }
 
 
@@ -145,7 +145,7 @@ class CommitServiceMockTest {
         when(branchService.getById(branchId)).thenReturn(branch);
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         lenient().when(cbsRepository.findById(baseCommit.getCommitMongoId())).thenReturn(
-                Optional.of(CommitTestUtils.createCommitBlockSequence()));
+                Optional.of(CommitMockTestUtils.createCommitBlockSequence()));
 
         try (MockedStatic<CommitBlockSequenceMapper> cbsMapperMock = mockStatic(
                 CommitBlockSequenceMapper.class);
@@ -181,7 +181,7 @@ class CommitServiceMockTest {
         when(branchService.getById(branchId)).thenReturn(branch);
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         lenient().when(cbsRepository.findById(baseCommit.getCommitMongoId())).thenReturn(
-                Optional.of(CommitTestUtils.createCommitBlockSequence()));
+                Optional.of(CommitMockTestUtils.createCommitBlockSequence()));
 
         try (MockedStatic<CommitBlockSequenceMapper> cbsMapperMock = mockStatic(
                 CommitBlockSequenceMapper.class);
@@ -208,7 +208,7 @@ class CommitServiceMockTest {
     @DisplayName("커밋 생성 성공 - leafCommit이 null인 경우 fromCommit 사용")
     void createCommit_Success_UseFromCommitWhenLeafCommitIsNull() {
         // Given
-        Branch branchWithoutLeafCommit = CommitTestUtils.createBranch(doc, baseCommit);
+        Branch branchWithoutLeafCommit = CommitMockTestUtils.createBranch(doc, baseCommit);
         branchWithoutLeafCommit.updateLeafCommit(null); // leafCommit을 null로 설정
 
         when(docService.getById(docId)).thenReturn(doc);
@@ -216,7 +216,7 @@ class CommitServiceMockTest {
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         when(cbsRepository.findById(
                 branchWithoutLeafCommit.getFromCommit().getCommitMongoId())).thenReturn(
-                Optional.of(CommitTestUtils.createCommitBlockSequence()));
+                Optional.of(CommitMockTestUtils.createCommitBlockSequence()));
 
         try (MockedStatic<CommitBlockSequenceMapper> cbsMapperMock = mockStatic(
                 CommitBlockSequenceMapper.class);
@@ -320,7 +320,7 @@ class CommitServiceMockTest {
                 "Test commit message",
                 "",
                 1L,
-                List.of(CommitTestUtils.createBlockRequest("block1")),
+                List.of(CommitMockTestUtils.createBlockRequest("block1")),
                 List.of("block1", "invalidBlock") // 존재하지 않는 블록
         );
         try (MockedStatic<CommitBlockSequenceMapper> cbsMapperMock = mockStatic(

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
@@ -13,7 +13,7 @@ import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
-import io.ejangs.docsa.domain.commit.util.CommitTestUtils;
+import io.ejangs.docsa.domain.commit.util.CommitMockTestUtils;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.user.entity.User;
@@ -55,20 +55,20 @@ class GetCommitMockTest {
     @BeforeEach
     void setUp() {
         // User 생성
-        user = CommitTestUtils.createUser();
+        user = CommitMockTestUtils.createUser();
 
         // Doc 생성
-        doc = CommitTestUtils.createDoc(user);
+        doc = CommitMockTestUtils.createDoc(user);
 
         // Branch 생성
-        branch = CommitTestUtils.createBranch(doc, baseCommit);
+        branch = CommitMockTestUtils.createBranch(doc, baseCommit);
 
         // BaseCommit 생성
-        baseCommit = CommitTestUtils.createBaseCommit(branch);
+        baseCommit = CommitMockTestUtils.createBaseCommit(branch);
         baseCommit.setBranch(branch);
 
-        targetCommit = CommitTestUtils.createMockCommit(branch, 2L);
-        mockContent = CommitTestUtils.createMockContent();
+        targetCommit = CommitMockTestUtils.createMockCommit(branch, 2L);
+        mockContent = CommitMockTestUtils.createMockContent();
     }
 
     @Test
@@ -141,8 +141,8 @@ class GetCommitMockTest {
         String baseCommitMongoId = "base-mongo-commit-id";
         String targetCommitMongoId = "mongo-commit-id";
 
-        List<Map<String, Object>> baseContent = CommitTestUtils.createMockContent();
-        List<Map<String, Object>> targetContent = CommitTestUtils.createMockContent();
+        List<Map<String, Object>> baseContent = CommitMockTestUtils.createMockContent();
+        List<Map<String, Object>> targetContent = CommitMockTestUtils.createMockContent();
 
         given(commitRepository.findById(baseId)).willReturn(Optional.of(baseCommit));
         given(commitRepository.findById(targetId)).willReturn(Optional.of(targetCommit));
@@ -194,7 +194,7 @@ class GetCommitMockTest {
         Long targetId = 999L;
         String baseCommitMongoId = "base-mongo-commit-id";
 
-        List<Map<String, Object>> baseContent = CommitTestUtils.createMockContent();
+        List<Map<String, Object>> baseContent = CommitMockTestUtils.createMockContent();
 
         given(commitRepository.findById(baseId)).willReturn(Optional.of(baseCommit));
         given(commitRepository.findById(targetId)).willReturn(Optional.empty());

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -1,0 +1,304 @@
+package io.ejangs.docsa.domain.commit.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.ejangs.docsa.domain.block.dto.response.BlockDto;
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
+import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
+import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
+import io.ejangs.docsa.domain.doc.dao.mysql.EdgeRepository;
+import io.ejangs.docsa.domain.doc.entity.Doc;
+import io.ejangs.docsa.domain.doc.entity.Edge;
+import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
+import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.BranchErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MergeCommitIntegrationTest {
+
+    @Autowired
+    private CommitService commitService;
+
+    @Autowired
+    private DocRepository docRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BranchRepository branchRepository;
+
+    @Autowired
+    private CommitRepository commitRepository;
+
+    @Autowired
+    private EdgeRepository edgeRepository;
+
+    private User testUser;
+    private Doc testDoc;
+    private Branch baseBranch;
+    private Branch targetBranch;
+    private Commit baseCommit;
+    private Commit targetCommit;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        testUser = createTestUser();
+        userRepository.save(testUser);
+
+        // 테스트 문서 생성
+        testDoc = createTestDoc();
+        docRepository.save(testDoc);
+
+        // 베이스 브랜치 생성
+        baseBranch = createTestBranch("main");
+        branchRepository.save(baseBranch);
+
+        // 타겟 브랜치 생성
+        targetBranch = createTestBranch("feature");
+        branchRepository.save(targetBranch);
+
+        // 베이스 커밋 생성
+        baseCommit = createTestCommit(baseBranch, "Base commit");
+        commitRepository.save(baseCommit);
+        baseBranch.updateLeafCommit(baseCommit);
+        baseBranch.initializeRootCommitIfNull(baseCommit);
+
+        // 타겟 커밋 생성
+        targetCommit = createTestCommit(targetBranch, "Target commit");
+        commitRepository.save(targetCommit);
+        targetBranch.updateLeafCommit(targetCommit);
+        targetBranch.initializeRootCommitIfNull(targetCommit);
+
+        System.out.println("before Test");
+    }
+
+    @Test
+    @DisplayName("정상적인 병합 커밋 생성 테스트")
+    void mergeCommit_Success() {
+        // given
+        MergeCommitRequest request = createMergeCommitRequest();
+
+        // when
+        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isNotNull();
+
+        // 병합 커밋이 생성되었는지 확인
+        Commit mergeCommit = commitRepository.findById(response.id()).orElse(null);
+        assertThat(mergeCommit).isNotNull();
+        assertThat(mergeCommit.getTitle()).isEqualTo("Merge commit");
+        assertThat(mergeCommit.getDescription()).isEqualTo("Merge feature into main");
+        assertThat(mergeCommit.getCommitMongoId()).isNotNull();
+
+        // 베이스 브랜치의 leafCommit이 업데이트되었는지 확인
+        Branch updatedBaseBranch = branchRepository.findById(baseBranch.getId()).orElse(null);
+        assertThat(updatedBaseBranch.getLeafCommit().getId()).isEqualTo(response.id());
+
+        branchRepository.flush();
+        System.out.println("updatedBaseBranch = " + updatedBaseBranch.getLeafCommit().getId());
+        // 두 개의 간선이 생성되었는지 확인
+        List<Edge> edges = edgeRepository.findByNextCommitId(response.id());
+
+        assertThat(edges).hasSize(2);
+
+        // 간선이 올바르게 생성되었는지 확인
+        List<Long> prevCommitIds = edges.stream()
+                .map(edge -> edge.getPrevCommit().getId())
+                .toList();
+
+        assertThat(prevCommitIds).containsExactlyInAnyOrder(
+                baseCommit.getId(),
+                targetCommit.getId()
+        );
+    }
+
+    @Test
+    @DisplayName("빈 컨텐츠로 병합 커밋 생성 테스트")
+    void mergeCommit_EmptyContent_Success() {
+        // given
+        MergeCommitRequest request = new MergeCommitRequest(
+                "Empty merge commit",
+                "Merge with empty content",
+                baseBranch.getId(),
+                targetBranch.getId(),
+                List.of()
+        );
+
+        // when
+        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isNotNull();
+
+        // 병합 커밋이 생성되었는지 확인
+        Commit mergeCommit = commitRepository.findById(response.id()).orElse(null);
+        assertThat(mergeCommit).isNotNull();
+        assertThat(mergeCommit.getTitle()).isEqualTo("Empty merge commit");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문서 ID로 병합 시도 시 예외 발생")
+    void mergeCommit_Document_NotFound() {
+        // given
+        Long nonExistentDocId = 999L;
+        MergeCommitRequest request = createMergeCommitRequest();
+
+        // when & then
+        assertThatThrownBy(() -> commitService.mergeCommit(nonExistentDocId, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(DocErrorCode.DOCUMENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 베이스 브랜치 ID로 병합 시도 시 예외 발생")
+    void mergeCommit_BaseBranch_NotFound() {
+        // given
+        MergeCommitRequest request = new MergeCommitRequest(
+                "Merge commit",
+                "Merge feature into main",
+                999L,   // 존재하지 않는 베이스 브랜치 ID
+                targetBranch.getId(),
+                createTestBlockContent()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 타겟 브랜치 ID로 병합 시도 시 예외 발생")
+    void mergeCommit_TargetBranch_NotFound() {
+        // given
+        MergeCommitRequest request = new MergeCommitRequest(
+                "Merge commit",
+                "Merge feature into main",
+                baseBranch.getId(),
+                999L,   // 존재하지 않는 타겟 브랜치 ID
+                createTestBlockContent()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("leafCommit이 없는 브랜치로 병합 시도 시 예외 발생")
+    void mergeCommit_NoLeafCommit() {
+        // given
+        Branch branchWithoutLeaf = createTestBranch("no-leaf");
+        branchRepository.save(branchWithoutLeaf);
+
+        MergeCommitRequest request = new MergeCommitRequest(
+                "Merge commit",
+                "Merge feature into main",
+                branchWithoutLeaf.getId(),
+                targetBranch.getId(),
+                createTestBlockContent()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(CommitErrorCode.COMMIT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("동일한 브랜치끼리 병합 시도 테스트")
+    void mergeCommit_SameBranch_Fail() {
+        // given
+        MergeCommitRequest request = new MergeCommitRequest(
+                "Self merge commit",
+                "Merge branch into itself",
+                baseBranch.getId(),
+                baseBranch.getId(), // 동일한 브랜치
+                createTestBlockContent()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(CommitErrorCode.COMMIT_BAD_REQUEST.getMessage());
+    }
+
+    private User createTestUser() {
+        return User.builder()
+                .email("test@example.com")
+                .name("Test User")
+                .password("password")
+                .build();
+    }
+
+    private Doc createTestDoc() {
+        return Doc.builder()
+                .title("Test Document")
+                .user(testUser)
+                .build();
+    }
+
+    private Branch createTestBranch(String name) {
+        return Branch.builder()
+                .name(name)
+                .doc(testDoc)
+                .build();
+    }
+
+    private Commit createTestCommit(Branch branch, String title) {
+        return Commit.builder()
+                .title(title)
+                .description("Test commit description")
+                .branch(branch)
+                .commitMongoId("test-mongo-id-" + System.currentTimeMillis())
+                .build();
+    }
+
+    private MergeCommitRequest createMergeCommitRequest() {
+        return new MergeCommitRequest(
+                "Merge commit",
+                "Merge feature into main",
+                baseBranch.getId(),
+                targetBranch.getId(),
+                createTestBlockContent()
+        );
+    }
+
+    private List<BlockDto> createTestBlockContent() {
+        return List.of(
+                new BlockDto(Map.of(
+                        "id", "block-1",
+                        "type", "paragraph",
+                        "data", Map.of("text", "Test content 1")
+                )),
+                new BlockDto(Map.of(
+                        "id", "block-2",
+                        "type", "paragraph",
+                        "data", Map.of("text", "Test content 2")
+                ))
+        );
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -10,6 +10,7 @@ import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.commit.util.CommitIntegrationTestUtils;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dao.mysql.EdgeRepository;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -21,7 +22,6 @@ import io.ejangs.docsa.global.exception.errorcode.BranchErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,43 +57,48 @@ class MergeCommitIntegrationTest {
     private Branch targetBranch;
     private Commit baseCommit;
     private Commit targetCommit;
+    private List<BlockDto> blockContent;
 
     @BeforeEach
     void setUp() {
         // 테스트 사용자 생성
-        testUser = createTestUser();
+        testUser = CommitIntegrationTestUtils.createTestUser();
         userRepository.save(testUser);
 
         // 테스트 문서 생성
-        testDoc = createTestDoc();
+        testDoc = CommitIntegrationTestUtils.createTestDoc(testUser);
         docRepository.save(testDoc);
 
         // 베이스 브랜치 생성
-        baseBranch = createTestBranch("main");
+        baseBranch = CommitIntegrationTestUtils.createTestBranch("main", testDoc);
         branchRepository.save(baseBranch);
 
         // 타겟 브랜치 생성
-        targetBranch = createTestBranch("feature");
+        targetBranch = CommitIntegrationTestUtils.createTestBranch("feature", testDoc);
         branchRepository.save(targetBranch);
 
         // 베이스 커밋 생성
-        baseCommit = createTestCommit(baseBranch, "Base commit");
+        baseCommit = CommitIntegrationTestUtils.createTestCommit(baseBranch, "Base commit");
         commitRepository.save(baseCommit);
         baseBranch.updateLeafCommit(baseCommit);
         baseBranch.initializeRootCommitIfNull(baseCommit);
 
         // 타겟 커밋 생성
-        targetCommit = createTestCommit(targetBranch, "Target commit");
+        targetCommit = CommitIntegrationTestUtils.createTestCommit(targetBranch, "Target commit");
         commitRepository.save(targetCommit);
         targetBranch.updateLeafCommit(targetCommit);
         targetBranch.initializeRootCommitIfNull(targetCommit);
+
+        // 전문 생성
+        blockContent = CommitIntegrationTestUtils.createTestBlockContent();
     }
 
     @Test
     @DisplayName("정상적인 병합 커밋 생성 테스트")
     void mergeCommit_Success() {
         // given
-        MergeCommitRequest request = createMergeCommitRequest();
+        MergeCommitRequest request =
+                CommitIntegrationTestUtils.createMergeCommitRequest(baseBranch, targetBranch);
 
         // when
         CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request);
@@ -159,7 +164,8 @@ class MergeCommitIntegrationTest {
     void mergeCommit_Document_NotFound() {
         // given
         Long nonExistentDocId = 999L;
-        MergeCommitRequest request = createMergeCommitRequest();
+        MergeCommitRequest request =
+                CommitIntegrationTestUtils.createMergeCommitRequest(baseBranch, targetBranch);
 
         // when & then
         assertThatThrownBy(() -> commitService.mergeCommit(nonExistentDocId, request))
@@ -176,7 +182,7 @@ class MergeCommitIntegrationTest {
                 "Merge feature into main",
                 999L,   // 존재하지 않는 베이스 브랜치 ID
                 targetBranch.getId(),
-                createTestBlockContent()
+                blockContent
         );
 
         // when & then
@@ -194,7 +200,7 @@ class MergeCommitIntegrationTest {
                 "Merge feature into main",
                 baseBranch.getId(),
                 999L,   // 존재하지 않는 타겟 브랜치 ID
-                createTestBlockContent()
+                blockContent
         );
 
         // when & then
@@ -207,7 +213,7 @@ class MergeCommitIntegrationTest {
     @DisplayName("leafCommit이 없는 브랜치로 병합 시도 시 예외 발생")
     void mergeCommit_NoLeafCommit() {
         // given
-        Branch branchWithoutLeaf = createTestBranch("no-leaf");
+        Branch branchWithoutLeaf = CommitIntegrationTestUtils.createTestBranch("no-leaf", testDoc);
         branchRepository.save(branchWithoutLeaf);
 
         MergeCommitRequest request = new MergeCommitRequest(
@@ -215,7 +221,7 @@ class MergeCommitIntegrationTest {
                 "Merge feature into main",
                 branchWithoutLeaf.getId(),
                 targetBranch.getId(),
-                createTestBlockContent()
+                blockContent
         );
 
         // when & then
@@ -233,68 +239,12 @@ class MergeCommitIntegrationTest {
                 "Merge branch into itself",
                 baseBranch.getId(),
                 baseBranch.getId(), // 동일한 브랜치
-                createTestBlockContent()
+                blockContent
         );
 
         // when & then
         assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(CommitErrorCode.COMMIT_BAD_REQUEST.getMessage());
-    }
-
-    private User createTestUser() {
-        return User.builder()
-                .email("test@example.com")
-                .name("Test User")
-                .password("password")
-                .build();
-    }
-
-    private Doc createTestDoc() {
-        return Doc.builder()
-                .title("Test Document")
-                .user(testUser)
-                .build();
-    }
-
-    private Branch createTestBranch(String name) {
-        return Branch.builder()
-                .name(name)
-                .doc(testDoc)
-                .build();
-    }
-
-    private Commit createTestCommit(Branch branch, String title) {
-        return Commit.builder()
-                .title(title)
-                .description("Test commit description")
-                .branch(branch)
-                .commitMongoId("test-mongo-id-" + System.currentTimeMillis())
-                .build();
-    }
-
-    private MergeCommitRequest createMergeCommitRequest() {
-        return new MergeCommitRequest(
-                "Merge commit",
-                "Merge feature into main",
-                baseBranch.getId(),
-                targetBranch.getId(),
-                createTestBlockContent()
-        );
-    }
-
-    private List<BlockDto> createTestBlockContent() {
-        return List.of(
-                new BlockDto(Map.of(
-                        "id", "block-1",
-                        "type", "paragraph",
-                        "data", Map.of("text", "Test content 1")
-                )),
-                new BlockDto(Map.of(
-                        "id", "block-2",
-                        "type", "paragraph",
-                        "data", Map.of("text", "Test content 2")
-                ))
-        );
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -87,8 +87,6 @@ class MergeCommitIntegrationTest {
         commitRepository.save(targetCommit);
         targetBranch.updateLeafCommit(targetCommit);
         targetBranch.initializeRootCommitIfNull(targetCommit);
-
-        System.out.println("before Test");
     }
 
     @Test
@@ -115,8 +113,6 @@ class MergeCommitIntegrationTest {
         Branch updatedBaseBranch = branchRepository.findById(baseBranch.getId()).orElse(null);
         assertThat(updatedBaseBranch.getLeafCommit().getId()).isEqualTo(response.id());
 
-        branchRepository.flush();
-        System.out.println("updatedBaseBranch = " + updatedBaseBranch.getLeafCommit().getId());
         // 두 개의 간선이 생성되었는지 확인
         List<Edge> edges = edgeRepository.findByNextCommitId(response.id());
 

--- a/src/test/java/io/ejangs/docsa/domain/commit/util/CommitIntegrationTestUtils.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/util/CommitIntegrationTestUtils.java
@@ -1,0 +1,69 @@
+package io.ejangs.docsa.domain.commit.util;
+
+import io.ejangs.docsa.domain.block.dto.response.BlockDto;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
+import io.ejangs.docsa.domain.commit.entity.Commit;
+import io.ejangs.docsa.domain.doc.entity.Doc;
+import io.ejangs.docsa.domain.user.entity.User;
+import java.util.List;
+import java.util.Map;
+
+public class CommitIntegrationTestUtils {
+
+    public static User createTestUser() {
+        return User.builder()
+                .email("test@example.com")
+                .name("Test User")
+                .password("password")
+                .build();
+    }
+
+    public static Doc createTestDoc(User testUser) {
+        return Doc.builder()
+                .title("Test Document")
+                .user(testUser)
+                .build();
+    }
+
+    public static Branch createTestBranch(String name, Doc testDoc) {
+        return Branch.builder()
+                .name(name)
+                .doc(testDoc)
+                .build();
+    }
+
+    public static Commit createTestCommit(Branch branch, String title) {
+        return Commit.builder()
+                .title(title)
+                .description("Test commit description")
+                .branch(branch)
+                .commitMongoId("test-mongo-id-" + System.currentTimeMillis())
+                .build();
+    }
+
+    public static MergeCommitRequest createMergeCommitRequest(Branch baseBranch, Branch targetBranch) {
+        return new MergeCommitRequest(
+                "Merge commit",
+                "Merge feature into main",
+                baseBranch.getId(),
+                targetBranch.getId(),
+                createTestBlockContent()
+        );
+    }
+
+    public static List<BlockDto> createTestBlockContent() {
+        return List.of(
+                new BlockDto(Map.of(
+                        "id", "block-1",
+                        "type", "paragraph",
+                        "data", Map.of("text", "Test content 1")
+                )),
+                new BlockDto(Map.of(
+                        "id", "block-2",
+                        "type", "paragraph",
+                        "data", Map.of("text", "Test content 2")
+                ))
+        );
+    }
+}

--- a/src/test/java/io/ejangs/docsa/domain/commit/util/CommitMockTestUtils.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/util/CommitMockTestUtils.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.test.util.ReflectionTestUtils;
 
-public class CommitTestUtils {
+public class CommitMockTestUtils {
 
     public static User createUser() {
         User user = User.builder()


### PR DESCRIPTION
## 🛰️ Issue Number
- #79

## 🪐 작업 내용
- 병합하기 API 입니다
- MongoDB에 비정형 데이터들을 먼저 저장하고, Entity를 MySql에 _id와 함께 저장합니다
- MySql에 저장이 실패하면 _id와 rollback메서드를 통해 MongoDB에 저장된 데이터를 지워 줍니다
- 현재 rollback중 예외가 발생했을 때 아무 대처가 없는데 스케줄러 적용 이후 해당 처리를 추가할 수 있을 것 같습니다
- Edge의 부자연스러웠던 연관관계를 수정했습니다
- Branch의 commits 필드에서 누락된 mappedBy 속성을 추가했습니다

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?