### PR TITLE
Refactor: `@AuthenticationPrincipal` 적용

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/api/BranchController.java
@@ -5,11 +5,18 @@ import io.ejangs.docsa.domain.branch.dto.request.BranchCreateRequest;
 import io.ejangs.docsa.domain.branch.dto.request.BranchRenameRequest;
 import io.ejangs.docsa.domain.branch.dto.response.BranchCreateResponse;
 import io.ejangs.docsa.domain.branch.dto.response.BranchRenameResponse;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,19 +27,22 @@ public class BranchController {
 
     // 브랜치에 이어서 새로운 저장 생성 or 새로운 브랜치 + 저장 생성
     @PostMapping
-    public ResponseEntity<BranchCreateResponse> createBranchOrSave(@RequestParam Long userId,
+    public ResponseEntity<BranchCreateResponse> createBranchOrSave(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long documentId, @Valid @RequestBody BranchCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(branchService.createBranchOrSave(documentId, request, userId));
+                .body(branchService.createBranchOrSave(documentId, request, userDetails.getId()));
     }
 
     // 브랜치 이름 수정
     @PatchMapping("/{branchId}")
-    public ResponseEntity<BranchRenameResponse> renameBranch(@RequestParam Long userId,
+    public ResponseEntity<BranchRenameResponse> renameBranch(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long documentId, @PathVariable Long branchId,
             @Valid @RequestBody BranchRenameRequest request) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(branchService.renameBranch(documentId, branchId, request.newName(), userId));
+                .body(branchService.renameBranch(documentId, branchId, request.newName(),
+                        userDetails.getId()));
     }
 
 }

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -5,17 +5,22 @@ import io.ejangs.docsa.domain.commit.dto.request.CreateCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
+/*
+@AuthenticationPrincipal CustomUserDetails userDetails 을 추가해놓음.
+추후 다른 PR에서 서비스 로직에서 관련 유효성 검사를 진행할 예정
+ */
 @RestController
 @RequiredArgsConstructor
 public class CommitController {
@@ -24,6 +29,7 @@ public class CommitController {
 
     @PostMapping("/api/document/{docId}/commit")
     public ResponseEntity<CreateCommitResponse> createCommit(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("docId") Long docId,
             @RequestBody @Valid CreateCommitRequest commitRequest) {
 
@@ -33,6 +39,7 @@ public class CommitController {
 
     @GetMapping("/api/document/{docId}/commit/{commitId}")
     public ResponseEntity<CommitResponse> getCommit(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("docId") Long docId,
             @PathVariable("commitId") Long commitId) {
 
@@ -42,6 +49,7 @@ public class CommitController {
 
     @GetMapping("/api/document/{docId}/merge")
     public ResponseEntity<CompareMergeCommitResponse> compareMergeCommit(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("docId") Long docId,
             @RequestParam("base") Long baseId,
             @RequestParam("target") Long targetId) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
@@ -7,11 +7,13 @@ import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,41 +31,44 @@ public class DocController {
     private final DocService docService;
 
     @PostMapping
-    public ResponseEntity<DocCreateResponse> create(@RequestParam Long userId,
+    public ResponseEntity<DocCreateResponse> create(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody DocTitleRequest request) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(docService.create(request, userId));
+                .body(docService.create(request, userDetails.getId()));
     }
 
     @GetMapping("/sidebar")
     public ResponseEntity<List<DocListSimpleResponse>> readListSidebar(
-            @RequestParam Long userId) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getSimpleList(userId));
+                .body(docService.getSimpleList(userDetails.getId()));
     }
 
     @GetMapping
-    public ResponseEntity<List<DocListResponse>> readList(@RequestParam Long userId) {
+    public ResponseEntity<List<DocListResponse>> readList(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getList(userId));
+                .body(docService.getList(userDetails.getId()));
     }
 
     @PatchMapping("/{docId}")
     public ResponseEntity<DocTitleUpdateResponse> updateDocumentTitle(
             @PathVariable Long docId,
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody DocTitleRequest request) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.updateTitle(userId, docId, request));
+                .body(docService.updateTitle(userDetails.getId(), docId, request));
     }
 
     @GetMapping("/{docId}/graph")
-    public ResponseEntity<CommitGraphResponse> getGraph(@RequestParam Long userId,
+    public ResponseEntity<CommitGraphResponse> getGraph(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long docId) {
-        return ResponseEntity.status(HttpStatus.OK).body(docService.getGraph(userId, docId));
+        return ResponseEntity.status(HttpStatus.OK).body(docService.getGraph(userDetails.getId(), docId));
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/api/SaveController.java
@@ -5,9 +5,11 @@ import io.ejangs.docsa.domain.save.dto.SaveIdentifierDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
 import io.ejangs.docsa.domain.save.dto.response.SaveGetResponse;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -24,21 +26,23 @@ public class SaveController {
     private final SaveService saveService;
 
     @GetMapping
-    public ResponseEntity<SaveGetResponse> getSave(@RequestParam Long userId,
+    public ResponseEntity<SaveGetResponse> getSave(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long saveId,
             @PathVariable Long documentId) {
         SaveGetResponse response = saveService.getSave(
-                SaveIdentifierDto.of(documentId, saveId, userId));
+                SaveIdentifierDto.of(documentId, saveId, userDetails.getId()));
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @PutMapping
-    public ResponseEntity<SaveUpdateResponse> updateSave(@RequestParam Long userId,
+    public ResponseEntity<SaveUpdateResponse> updateSave(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long documentId,
             @PathVariable Long saveId,
             @RequestBody SaveUpdateRequest saveUpdateRequest) {
         SaveUpdateResponse response = saveService.updateSave(
-                SaveIdentifierDto.of(documentId, saveId, userId), saveUpdateRequest);
+                SaveIdentifierDto.of(documentId, saveId, userDetails.getId()), saveUpdateRequest);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/io/ejangs/docsa/domain/user/security/CustomUserDetails.java
@@ -1,6 +1,8 @@
 package io.ejangs.docsa.domain.user.security;
 
 import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.AuthErrorCode;
 import java.util.Collection;
 import java.util.Collections;
 import lombok.Getter;
@@ -60,5 +62,13 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public Long getId() {
+        if (this.id != null) {
+            return this.id;
+        } else {
+            throw new CustomException(AuthErrorCode.AUTHENTICATION_FAILED);
+        }
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/auth/api/AuthControllerTest.java
@@ -274,7 +274,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("비밀번호 변경 시 존재하지 않는 사용자인 경우 400 에러 발생")
+    @DisplayName("비밀번호 변경 시 존재하지 않는 사용자인 경우 404 에러 발생")
     void checkCode_ResetPasswordWithUnknownUser() throws Exception {
         // given
         CodeCheckRequest request = new CodeCheckRequest("unknown@example.com", "CODE999", CodeType.RESET_PASSWORD);
@@ -286,9 +286,9 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/auth/code/check")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("USER_NOT_FOUND_FOR_RESET"))
-                .andExpect(jsonPath("$.message").value("비밀번호 변경을 위한 사용자를 찾을 수 없습니다."))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("USER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."))
                 .andDo(print());
 
         verify(authService).checkCode(request);

--- a/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/branch/api/BranchControllerTest.java
@@ -6,6 +6,7 @@ import io.ejangs.docsa.domain.branch.dto.request.BranchCreateRequest;
 import io.ejangs.docsa.domain.branch.dto.response.BranchCreateResponse;
 import io.ejangs.docsa.domain.branch.dto.request.BranchRenameRequest;
 import io.ejangs.docsa.domain.branch.dto.response.BranchRenameResponse;
+import io.ejangs.docsa.global.security.WithCustomMockUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BranchController.class)
+@WithCustomMockUser
 @AutoConfigureMockMvc(addFilters = false)
 class BranchControllerTest {
 
@@ -39,7 +41,7 @@ class BranchControllerTest {
     void createBranchOrSave_success() throws Exception {
         // given
         Long documentId = 1L;
-        Long mockUserId = 99L;
+        Long mockUserId = 1L;
         BranchCreateRequest request = new BranchCreateRequest("기능 브랜치", 100L);
         BranchCreateResponse response = new BranchCreateResponse(200L, 300L);
 
@@ -48,7 +50,6 @@ class BranchControllerTest {
 
         // when + then
         mockMvc.perform(post("/api/document/{documentId}/branch", documentId)
-                        .param("userId", mockUserId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -60,7 +61,7 @@ class BranchControllerTest {
     void renameBranch_success() throws Exception {
         Long documentId = 1L;
         Long branchId = 2L;
-        Long userId = 3L;
+        Long userId = 1L;
         String newName = "수정된 이름";
 
         BranchRenameRequest request = new BranchRenameRequest(newName);
@@ -70,7 +71,6 @@ class BranchControllerTest {
                 .thenReturn(response);
 
         mockMvc.perform(patch("/api/document/{documentId}/branch/{branchId}", documentId, branchId)
-                        .param("userId", String.valueOf(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
@@ -22,6 +22,7 @@ import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
+import io.ejangs.docsa.global.security.WithCustomMockUser;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(DocController.class)
+@WithCustomMockUser
 @AutoConfigureMockMvc(addFilters = false)
 class DocControllerUnitTests {
 
@@ -60,7 +62,6 @@ class DocControllerUnitTests {
                 .thenReturn(new DocCreateResponse(documentId));
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/document")
-                        .param("userId", "1")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .with(csrf()))
@@ -75,7 +76,6 @@ class DocControllerUnitTests {
         DocTitleRequest request = new DocTitleRequest("");
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/document")
-                        .param("userId", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -87,8 +87,6 @@ class DocControllerUnitTests {
     @DisplayName("문서 리스트 조회 컨트롤러 테스트 - 사이드바")
     void getSimpleDocList() throws Exception {
         // given
-        Long userId = 1L;
-
         List<DocListSimpleResponse> responseList = List.of(
                 new DocListSimpleResponse(
                         1L,
@@ -109,8 +107,7 @@ class DocControllerUnitTests {
         when(docService.getSimpleList(anyLong())).thenReturn(responseList);
 
         // when, then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/sidebar")
-                        .param("userId", String.valueOf(userId)))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/sidebar"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.size()").value(2))
                 .andExpect(jsonPath("$[0].title").value("마이크로소프트"))
@@ -142,7 +139,6 @@ class DocControllerUnitTests {
 
         //when & then
         mockMvc.perform(MockMvcRequestBuilders.patch("/api/document/" + docId)
-                        .param("userId", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -165,7 +161,6 @@ class DocControllerUnitTests {
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.patch("/api/document/{documentId}", documentId)
-                        .param("userId", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -175,13 +170,11 @@ class DocControllerUnitTests {
     @DisplayName("문서 제목 수정 - 문서 제목이 50자 초과")
     void updateDocTitleFailByTooLongTitle() throws Exception {
         //given
-        Long userId = 1L;
         Long documentId = 10L;
         String tooLongTitle = "ThisTitleIsDefinitelyLongerThanFiftyCharactersInTotalLength!";
         DocTitleRequest request = new DocTitleRequest(tooLongTitle);
 
         mockMvc.perform(MockMvcRequestBuilders.patch("/api/document/{documentId}", documentId)
-                        .param("userId", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -194,7 +187,7 @@ class DocControllerUnitTests {
     void getGraphSuccess() throws Exception {
         // given
         Long docId = 1L;
-        Long userId = 99L;
+        Long userId = 1L;
 
         CommitDto commit = new CommitDto(11L, 101L, "커밋1", "설명1", LocalDateTime.now());
         EdgeDto edge = new EdgeDto(11L, 12L);
@@ -210,8 +203,7 @@ class DocControllerUnitTests {
         when(docService.getGraph(userId, docId)).thenReturn(response);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/{docId}/graph",docId)
-                .param("userId", String.valueOf(userId)))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/{docId}/graph", docId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("문서 제목"))
                 .andExpect(jsonPath("$.commits").isArray())
@@ -225,17 +217,13 @@ class DocControllerUnitTests {
     void getGraphFailByNotFound() throws Exception {
         // given
         Long docId = 999L;
-        Long userId = 99L;
-        when(docService.getGraph(docId, userId))
+        Long userId = 1L;
+        when(docService.getGraph(userId, docId))
                 .thenThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
-
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/{documentId}/graph", docId, userId))
-                .andExpect(status().isBadRequest())
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/document/{docId}/graph", docId))
+                .andExpect(status().isNotFound())
                 .andDo(print());
     }
-
-
-
 }
 

--- a/src/test/java/io/ejangs/docsa/domain/save/api/SaveControllerTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/save/api/SaveControllerTest.java
@@ -13,6 +13,7 @@ import io.ejangs.docsa.domain.save.dto.SaveBlock;
 import io.ejangs.docsa.domain.save.dto.SaveIdentifierDto;
 import io.ejangs.docsa.domain.save.dto.request.SaveUpdateRequest;
 import io.ejangs.docsa.domain.save.dto.response.SaveUpdateResponse;
+import io.ejangs.docsa.global.security.WithCustomMockUser;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @WebMvcTest(controllers = SaveController.class)
+@WithCustomMockUser
 @AutoConfigureMockMvc(addFilters = false)
 class SaveControllerTest {
 

--- a/src/test/java/io/ejangs/docsa/global/security/WithCustomMockUser.java
+++ b/src/test/java/io/ejangs/docsa/global/security/WithCustomMockUser.java
@@ -1,0 +1,19 @@
+package io.ejangs.docsa.global.security;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    long id() default 1L;
+    String email() default "test@example.com";
+    String password() default "password";
+}

--- a/src/test/java/io/ejangs/docsa/global/security/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/io/ejangs/docsa/global/security/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,31 @@
+package io.ejangs.docsa.global.security;
+
+import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WithCustomMockUserSecurityContextFactory implements
+        WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        User testUser = User.builder()
+                .email(annotation.email())
+                .password(annotation.password())
+                .build();
+        ReflectionTestUtils.setField(testUser, "id", annotation.id());
+
+        CustomUserDetails principal = CustomUserDetails.from(testUser);
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(principal, null, null);
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #86 

## 🪐 작업 내용
- `@AuthenticationPrincipal` 을 적용하여 더 이상 컨트롤러에서 userId를 쿼리 파라미터로 받지 않습니다.
- Test에서 `@AuthenticationPrincipal` 을 적용하기 위해 /test/global/security 안에 관련 클래스를 2개 만들었습니다. 코드는 아래에 첨부하겠습니다.
- 해당 어노테이션 도입 후 발생하는 테스트 에러도 해결하였습니다. 

```java
@Target({ ElementType.METHOD, ElementType.TYPE })
@Retention(RetentionPolicy.RUNTIME)
@Documented
@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
public @interface WithCustomMockUser {
    long id() default 1L;
    String email() default "test@example.com";
    String password() default "password";
}
```
- 기본적으로 존재하는 @WithMockUser 어노테이션이 있긴한데, 이건 저희가 만든 CustomUserDetails를 반환하지 않아 새로 만들었습니다.
```java
public class WithCustomMockUserSecurityContextFactory implements
        WithSecurityContextFactory<WithCustomMockUser> {

    @Override
    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
        User testUser = User.builder()
                .email(annotation.email())
                .password(annotation.password())
                .build();
        ReflectionTestUtils.setField(testUser, "id", annotation.id());

        CustomUserDetails principal = CustomUserDetails.from(testUser);

        UsernamePasswordAuthenticationToken authentication =
                new UsernamePasswordAuthenticationToken(principal, null, null);

        SecurityContext context = SecurityContextHolder.createEmptyContext();
        context.setAuthentication(authentication);
        return context;
    }
}
```
- 제가 만든 WithCustomMockUser 을 통해 SecurityContext 에 값을 세팅해준다고 생각하시면 됩니다. (매 테스트마다 새로 세팅)
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?