### PR TITLE
Refactor: 문서 조회 페이지네이션 적용(메인/사이드바)

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
@@ -10,7 +10,6 @@ import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,11 +43,18 @@ public class DocController {
     }
 
     @GetMapping("/sidebar")
-    public ResponseEntity<List<DocListSimpleResponse>> readListSidebar(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<Page<DocListSimpleResponse>> readListSidebar(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "updatedAt") String sort,
+            @RequestParam(defaultValue = "desc") String order,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageableFactory.create(sort, order, page, size);
+
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getSimpleList(userDetails.getId()));
+                .body(docService.getSimpleList(userDetails.getId(), pageable));
     }
 
     @GetMapping

--- a/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
@@ -7,14 +7,17 @@ import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
+import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,11 +52,18 @@ public class DocController {
     }
 
     @GetMapping
-    public ResponseEntity<List<DocListResponse>> readList(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<Page<DocListResponse>> readList(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "updatedAt") String sort,
+            @RequestParam(defaultValue = "desc") String order,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageableFactory.create(sort, order, page, size);
+
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getList(userDetails.getId()));
+                .body(docService.getList(userDetails.getId(), pageable));
     }
 
     @PatchMapping("/{docId}")
@@ -70,7 +80,8 @@ public class DocController {
     public ResponseEntity<CommitGraphResponse> getGraph(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long docId) {
-        return ResponseEntity.status(HttpStatus.OK).body(docService.getGraph(userDetails.getId(), docId));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(docService.getGraph(userDetails.getId(), docId));
     }
 
     @DeleteMapping("/{docId}")

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -40,6 +40,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,17 +128,16 @@ public class DocService {
     }
 
     @Transactional(readOnly = true)
-    public List<DocListResponse> getList(Long userId) {
-        List<Doc> docs = docRepository.findAllByUserId(userId);
+    public Page<DocListResponse> getList(Long userId, Pageable pageable) {
+        Page<Doc> docs = docRepository.findAllByUserId(userId, pageable);
 
-        return docs.stream()
+        return docs
                 .map(doc -> {
                     Branch recentBranch = getMostRecentBranch(doc);
                     RecentActivityDto recent = getRecentActivity(recentBranch);
                     String preview = extractPreviewSafe(recentBranch, recent);
                     return DocMapper.toListResponse(doc, preview, recent);
-                })
-                .toList();
+                });
     }
 
     private String extractPreviewSafe(Branch branch, RecentActivityDto recent) {

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -115,16 +115,15 @@ public class DocService {
     }
 
     @Transactional(readOnly = true)
-    public List<DocListSimpleResponse> getSimpleList(Long userId) {
-        List<Doc> docs = docRepository.findAllByUserId(userId);
+    public Page<DocListSimpleResponse> getSimpleList(Long userId, Pageable pageable) {
+        Page<Doc> docs = docRepository.findAllByUserId(userId, pageable);
 
-        return docs.stream()
+        return docs
                 .map(doc -> {
                     Branch recentBranch = getMostRecentBranch(doc);
                     RecentActivityDto recent = getRecentActivity(recentBranch);
                     return DocMapper.toListSimpleResponse(doc, recent);
-                })
-                .toList();
+                });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
@@ -1,9 +1,9 @@
 package io.ejangs.docsa.domain.doc.dao.mysql;
 
 import io.ejangs.docsa.domain.doc.entity.Doc;
-
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,13 +11,13 @@ import org.springframework.data.repository.query.Param;
 public interface DocRepository extends JpaRepository<Doc, Long> {
 
     @Query("""
-        SELECT DISTINCT d
-        FROM Doc d
-        LEFT JOIN FETCH d.branches b
-        LEFT JOIN FETCH b.commits
-        LEFT JOIN FETCH d.edges
-        WHERE d.id = :id
-    """)
+                SELECT DISTINCT d
+                FROM Doc d
+                LEFT JOIN FETCH d.branches b
+                LEFT JOIN FETCH b.commits
+                LEFT JOIN FETCH d.edges
+                WHERE d.id = :id
+            """)
     Optional<Doc> findByIdWithBranchesAndEdges(@Param("id") Long id);
 
     Optional<Doc> getDocByIdAndUserId(Long id, Long userId);
@@ -26,5 +26,5 @@ public interface DocRepository extends JpaRepository<Doc, Long> {
 
     boolean existsByIdAndUserId(Long Id, Long userId);
 
-    List<Doc> findAllByUserId(Long userId);
+    Page<Doc> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
@@ -1,6 +1,7 @@
 package io.ejangs.docsa.domain.doc.dao.mysql;
 
 import io.ejangs.docsa.domain.doc.entity.Doc;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,4 +28,7 @@ public interface DocRepository extends JpaRepository<Doc, Long> {
     boolean existsByIdAndUserId(Long Id, Long userId);
 
     Page<Doc> findAllByUserId(Long userId, Pageable pageable);
+
+    //페이지네이션 적용안된 사이드바 문서조회 임시조치용
+    List<Doc> findAllByUserId(Long userId);
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
@@ -29,6 +29,5 @@ public interface DocRepository extends JpaRepository<Doc, Long> {
 
     Page<Doc> findAllByUserId(Long userId, Pageable pageable);
 
-    //페이지네이션 적용안된 사이드바 문서조회 임시조치용
     List<Doc> findAllByUserId(Long userId);
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
@@ -18,7 +18,7 @@ public enum PageDirectionType {
     }
 
     public static PageDirectionType from(String value) {
-        return switch (value) {
+        return switch (value.toUpperCase()) {
             case "ASC" -> PageDirectionType.ASC;
             case "DESC" -> PageDirectionType.DESC;
             default -> throw new CustomException(PageErrorCode.UNSUPPORTED_DIRECTION_TYPE);

--- a/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
@@ -21,7 +21,7 @@ public enum PageDirectionType {
         return switch (value) {
             case "ASC" -> PageDirectionType.ASC;
             case "DESC" -> PageDirectionType.DESC;
-            default -> throw new CustomException(PageErrorCode.UNSUPPORTED_DIRECTION_TYPE)
+            default -> throw new CustomException(PageErrorCode.UNSUPPORTED_DIRECTION_TYPE);
         };
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
@@ -1,5 +1,7 @@
 package io.ejangs.docsa.domain.doc.model;
 
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.PageErrorCode;
 import lombok.Getter;
 import org.springframework.data.domain.Sort;
 
@@ -16,11 +18,12 @@ public enum PageDirectionType {
     }
 
     public static PageDirectionType from(String value) {
-        try {
-            return PageDirectionType.valueOf(value.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("지원하지 않는 정렬 방향입니다: " + value);
-        }
+        return switch (value) {
+            case "ASC" -> PageDirectionType.ASC;
+            case "DESC" -> PageDirectionType.DESC;
+            default -> throw new CustomException(PageErrorCode.UNSUPPORTED_DIRECTION_TYPE)
+        };
     }
+
 }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/model/PageDirectionType.java
@@ -1,0 +1,26 @@
+package io.ejangs.docsa.domain.doc.model;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public enum PageDirectionType {
+    ASC(Sort.Direction.ASC),
+    DESC(Sort.Direction.DESC);
+
+    private final Sort.Direction direction;
+
+
+    PageDirectionType(Sort.Direction direction) {
+        this.direction = direction;
+    }
+
+    public static PageDirectionType from(String value) {
+        try {
+            return PageDirectionType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 정렬 방향입니다: " + value);
+        }
+    }
+}
+

--- a/src/main/java/io/ejangs/docsa/domain/doc/model/PageSortType.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/model/PageSortType.java
@@ -1,0 +1,31 @@
+package io.ejangs.docsa.domain.doc.model;
+
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.PageErrorCode;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public enum PageSortType {
+    UPDATED_AT("updatedAt"),
+    TITLE("title");
+
+    private final String value;
+
+    private static final Map<String, PageSortType> CACHE = Arrays.stream(values())
+            .collect(Collectors.toMap(v -> v.value.toLowerCase(), v -> v));
+
+    PageSortType(String value) {
+        this.value = value;
+    }
+
+    public static PageSortType from(String value) {
+        PageSortType type = CACHE.get(value.toLowerCase());
+        if (type == null) {
+            throw new CustomException(PageErrorCode.UNSUPPORTED_SORT_TYPE);
+        }
+        return type;
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/save/util/PageableFactory.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/util/PageableFactory.java
@@ -1,0 +1,26 @@
+package io.ejangs.docsa.domain.save.util;
+
+import io.ejangs.docsa.domain.doc.model.PageDirectionType;
+import io.ejangs.docsa.domain.doc.model.PageSortType;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.PageErrorCode;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PageableFactory {
+
+    public static Pageable create(String sortParam, String dirParam, int page, int size) {
+        if (page < 0) {
+            throw new CustomException(PageErrorCode.INVALID_PAGE);
+        }
+        if (size <= 0) {
+            throw new CustomException(PageErrorCode.INVALID_PAGE_SIZE);
+        }
+
+        PageSortType sort = PageSortType.from(sortParam);
+        PageDirectionType dir = PageDirectionType.from(dirParam);
+
+        return PageRequest.of(page, size, Sort.by(dir.getDirection(), sort.getValue()));
+    }
+}

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/PageErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/PageErrorCode.java
@@ -1,0 +1,19 @@
+package io.ejangs.docsa.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PageErrorCode implements ErrorCode {
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 기준입니다.", "UNSUPPORTED_SORT_TYPE"),
+    UNSUPPORTED_DIRECTION_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방향입니다.",
+            "UNSUPPORTED_DIRECTION_TYPE"),
+    INVALID_PAGE(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE"),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지 크기는 0 이상이어야 합니다.", "INVALID_PAGE_SIZE");
+
+    private final HttpStatus status;
+    private final String message;
+    private final String error;
+}

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DocServiceIntegrationTests {
 
     @Autowired
@@ -81,6 +83,7 @@ public class DocServiceIntegrationTests {
 
     @AfterEach
     void cleanup() {
+        docRepository.deleteAll();
         saveContentRepository.deleteAll();
     }
 
@@ -202,8 +205,11 @@ public class DocServiceIntegrationTests {
                 saveContentRepository, commitBlockSequenceRepository, blockRepository);
         docRepository.saveAll(docs);
 
+        Pageable pageable = PageableFactory.create("updatedAt", "asc", 0, 10);
+
         // when
-        List<DocListSimpleResponse> results = docService.getSimpleList(user.getId());
+        Page<DocListSimpleResponse> page = docService.getSimpleList(user.getId(), pageable);
+        List<DocListSimpleResponse> results = page.getContent();
 
         // then
         assertEquals(2, results.size());

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -249,4 +249,28 @@ public class DocServiceIntegrationTests {
         assertEquals(RecentType.SAVE, first.recent().recentType());
         assertTrue(first.preview().startsWith("문단 3: 테스트 코드가 너무 싫어서 미치겠다는 문단")); // preview 포함
     }
+
+    @Test
+    @DisplayName("문서 리스트 조회 - 페이지네이션 테스트 100개의 문서를 만들고 페이지 0에서는 10개만 조회한다.")
+    void getDocListInPage() throws Exception {
+        //given
+        User user = userRepository.save(DocTestUtils.createUser());
+        List<Doc> docs = DocTestUtils.createDocList(100, user);
+        docRepository.saveAll(docs);
+
+        Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
+
+        //when
+        Page<DocListResponse> result = docService.getList(user.getId(), pageable);
+
+        //then
+        assertEquals(10, result.getContent().size());
+        DocListResponse first = result.getContent().getFirst();
+        assertEquals("테스트 문서 100", first.title());
+        assertEquals(100L, first.id());
+
+        DocListResponse last = result.getContent().getLast();
+        assertEquals("테스트 문서 91", last.title());
+        assertEquals(91L, last.id());
+    }
 }

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -26,6 +26,7 @@ import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
 import io.ejangs.docsa.domain.save.document.SaveContent;
 import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
@@ -40,6 +41,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -227,21 +230,23 @@ public class DocServiceIntegrationTests {
                 saveContentRepository, commitBlockSequenceRepository, blockRepository);
         docRepository.saveAll(docs);
 
+        Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
+
         // when
-        List<DocListResponse> results = docService.getList(user.getId());
+        Page<DocListResponse> results = docService.getList(user.getId(), pageable);
 
         // then
-        assertEquals(2, results.size());
+        assertEquals(2, results.getContent().size());
 
-        DocListResponse first = results.get(0);  // updatedAt 기준 최신
-        DocListResponse second = results.get(1);
+        DocListResponse first = results.getContent().getFirst();  // updatedAt 기준 최신
+        DocListResponse second = results.getContent().get(1);
 
-        assertEquals("문서 1", first.title());
-        assertEquals(RecentType.COMMIT, first.recent().recentType());
-        assertTrue(first.preview().startsWith("문단 5: 몰라어쩌구저꺼궁롱ㄹ라알이;ㅇㄹ")); // preview 포함
+        assertEquals("문서 1", second.title());
+        assertEquals(RecentType.COMMIT, second.recent().recentType());
+        assertTrue(second.preview().startsWith("문단 5: 몰라어쩌구저꺼궁롱ㄹ라알이;ㅇㄹ")); // preview 포함
 
-        assertEquals("문서 2", second.title());
-        assertEquals(RecentType.SAVE, second.recent().recentType());
-        assertTrue(second.preview().startsWith("문단 3: 테스트 코드가 너무 싫어서 미치겠다는 문단")); // preview 포함
+        assertEquals("문서 2", first.title());
+        assertEquals(RecentType.SAVE, first.recent().recentType());
+        assertTrue(first.preview().startsWith("문단 3: 테스트 코드가 너무 싫어서 미치겠다는 문단")); // preview 포함
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
@@ -21,6 +21,7 @@ import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
+import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.security.WithCustomMockUser;
@@ -31,6 +32,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -90,7 +95,7 @@ class DocControllerUnitTests {
     @DisplayName("문서 리스트 조회 컨트롤러 테스트 - 사이드바")
     void getSimpleDocList() throws Exception {
         // given
-        List<DocListSimpleResponse> responseList = List.of(
+        List<DocListSimpleResponse> content = List.of(
                 new DocListSimpleResponse(
                         1L,
                         "마이크로소프트",
@@ -107,18 +112,26 @@ class DocControllerUnitTests {
                 )
         );
 
-        when(docService.getSimpleList(anyLong())).thenReturn(responseList);
+        Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
+
+        Page<DocListSimpleResponse> responseList = new PageImpl<>(
+                content,
+                PageRequest.of(0, 10),
+                content.size()
+        );
+
+        when(docService.getSimpleList(anyLong(), any(Pageable.class))).thenReturn(responseList);
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders.get("/api/document/sidebar"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(2))
-                .andExpect(jsonPath("$[0].title").value("마이크로소프트"))
-                .andExpect(jsonPath("$[0].recent.recentType").value("SAVE"))
-                .andExpect(jsonPath("$[0].recent.recentTypeId").value(10))
-                .andExpect(jsonPath("$[1].title").value("구글"))
-                .andExpect(jsonPath("$[1].recent.recentType").value("COMMIT"))
-                .andExpect(jsonPath("$[1].recent.recentTypeId").value(11))
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("마이크로소프트"))
+                .andExpect(jsonPath("$.content[0].recent.recentType").value("SAVE"))
+                .andExpect(jsonPath("$.content[0].recent.recentTypeId").value(10))
+                .andExpect(jsonPath("$.content[1].title").value("구글"))
+                .andExpect(jsonPath("$.content[1].recent.recentType").value("COMMIT"))
+                .andExpect(jsonPath("$.content[1].recent.recentTypeId").value(11))
                 .andDo(print());
     }
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -17,6 +17,7 @@ import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.doc.util.DocTestUtils;
+import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
@@ -29,6 +30,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,13 +55,20 @@ public class DocServiceUnitTests {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long docId = 10L;
-        List<Doc> docs = DocTestUtils.createDocumentListForUnitTest(2, user);
+        List<Doc> content = DocTestUtils.createDocumentListForUnitTest(2, user);
+        Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
 
-        when(docRepository.findAllByUserId(userId)).thenReturn(docs);
+        Page<Doc> docs = new PageImpl<>(
+                content,
+                PageRequest.of(0, 10),
+                content.size()
+        );
+
+        when(docRepository.findAllByUserId(userId, pageable)).thenReturn(docs);
 
         // when
-        List<DocListSimpleResponse> result = docService.getSimpleList(userId);
-
+        Page<DocListSimpleResponse> page = docService.getSimpleList(userId, pageable);
+        List<DocListSimpleResponse> result = page.getContent();
         // then
         assertEquals(2, result.size());
         assertEquals("테스트 문서 1", result.getFirst().title());
@@ -67,7 +79,7 @@ public class DocServiceUnitTests {
         assertEquals(RecentType.COMMIT, result.getLast().recent().recentType());
         assertEquals(200L, result.getLast().recent().recentTypeId());
 
-        verify(docRepository).findAllByUserId(userId);
+        verify(docRepository).findAllByUserId(userId, pageable);
     }
 
     @Test

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -50,7 +50,7 @@ public class DocServiceUnitTests {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long docId = 10L;
-        List<Doc> docs = DocTestUtils.createDocumentList(2, user);
+        List<Doc> docs = DocTestUtils.createDocumentListForUnitTest(2, user);
 
         when(docRepository.findAllByUserId(userId)).thenReturn(docs);
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
@@ -22,7 +22,27 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class DocTestUtils {
 
-    public static List<Doc> createDocumentList(int count, User user) {
+    public static List<Doc> createDocList(int count, User user) {
+        List<Doc> docs = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            Doc doc = Doc.builder()
+                    .title("테스트 문서 " + i)
+                    .user(user)
+                    .build();
+
+            Branch branch = Branch.builder()
+                    .name("테스트 브랜치" + i)
+                    .doc(doc)
+                    .build();
+
+            doc.addBranch(branch);
+            docs.add(doc);
+        }
+        return docs;
+    }
+
+    public static List<Doc> createDocumentListForUnitTest(int count, User user) {
         List<Doc> docs = new ArrayList<>();
         LocalDateTime baseTime = LocalDateTime.of(2025, 7, 16, 1, 0);
 

--- a/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTestService.java
+++ b/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTestService.java
@@ -1,20 +1,21 @@
-package io.ejangs.docsa.global.mongo.deletion.app;
+package io.ejangs.docsa.mongoDeleteSystem;
 
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.save.document.SaveContent;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class MongoTransactionTestService {
 
-    private final SaveContentRepository saveContentRepository;
+    @Autowired
+    private SaveContentRepository saveContentRepository;
 
-    private final CommitRepository commitRepository;
+    @Autowired
+    private CommitRepository commitRepository;
 
     @Transactional(transactionManager = "mongoTransactionManager")
     public void saveContent() {

--- a/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTests.java
+++ b/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTests.java
@@ -2,15 +2,17 @@ package io.ejangs.docsa.mongoDeleteSystem;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
-import io.ejangs.docsa.global.mongo.deletion.app.MongoTransactionTestService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MongoTransactionTests {
 
     @Autowired
@@ -22,10 +24,14 @@ class MongoTransactionTests {
     @Autowired
     CommitRepository commitRepository;
 
+    @Autowired
+    BranchRepository branchRepository;
+
     @BeforeEach
     void setUp() {
-        saveContentRepository.deleteAll();
+        branchRepository.deleteAll();
         commitRepository.deleteAll();
+        saveContentRepository.deleteAll();
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
   h2:


### PR DESCRIPTION
## 🛰️ Issue Number
- #100 

## 🪐 작업 내용
메인페이지/사이드바 문서조회에 페이지네이션을 적용했습니다.
프론트에서의 파라미터에 따라 정렬기준이 다른 페이지를 응답합니다.
파라미터의 값을 검증하도록 했습니다.
- sort: 정렬 기준 (기본값: updatedAt) - **updatedAt**과 **title**요청 가능(다른 값 요청시 예외처리)
- order: 정렬 방향 (**asc**, **desc**, 기본: desc) - 다른 값 요청시 예외처리
- page: 페이지 번호 (0부터 시작) - 음수 요청시 예외처리
- size: 한 페이지에 가져올 문서 수 (기본: 10) - 음수 요청시 예외처리

페이지네이션에 의해 응답형식이 달라졌습니다.
자세한 사항은 api명세서에 기록해두었습니다.

페이지네이션 도입으로인해 프론트가 전체문서리스트를 가지고있지 않아서 검색 api를 개발해야할 것 같습니다. 저만의 구상으로는 제목+본문 검색이 되면 좋을것 같다는 생각을 가지고 있습니다.

테스트코드는 기존의 문서조회 테스트를 페이지네이션을 적용하여 수정하였습니다.
## 📚 Reference
[메인화면 api명세서](https://www.notion.so/7-22-22915a012054803c959bc98d72a02124)
[사이드바 api명세서](https://www.notion.so/7-22-22915a01205480c9be0cc4a2b711c55e)
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?