### PR TITLE
Refactor: CommitService에서 User관련 유효성 검사 추가

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 /*
 @AuthenticationPrincipal CustomUserDetails userDetails 을 추가해놓음.
 추후 다른 PR에서 서비스 로직에서 관련 유효성 검사를 진행할 예정
@@ -56,7 +57,8 @@ public class CommitController {
             @RequestParam("target") Long targetId) {
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(commitService.compareCommitForMerge(docId, baseId, targetId));
+                .body(commitService.compareCommitForMerge(docId, baseId, targetId,
+                        userDetails.getId()));
     }
 
     @PostMapping("/api/document/{docId}/merge")

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -35,7 +35,7 @@ public class CommitController {
             @RequestBody @Valid CreateCommitRequest commitRequest) {
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(commitService.createCommit(docId, commitRequest));
+                .body(commitService.createCommit(docId, commitRequest, userDetails.getId()));
     }
 
     @GetMapping("/api/document/{docId}/commit/{commitId}")

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -63,10 +63,11 @@ public class CommitController {
 
     @PostMapping("/api/document/{docId}/merge")
     public ResponseEntity<CreateCommitResponse> mergeCommit(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("docId") Long docId,
             @RequestBody @Valid MergeCommitRequest mergeRequest) {
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(commitService.mergeCommit(docId, mergeRequest));
+                .body(commitService.mergeCommit(docId, mergeRequest, userDetails.getId()));
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -19,10 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/*
-@AuthenticationPrincipal CustomUserDetails userDetails 을 추가해놓음.
-추후 다른 PR에서 서비스 로직에서 관련 유효성 검사를 진행할 예정
- */
 @RestController
 @RequiredArgsConstructor
 public class CommitController {

--- a/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/api/CommitController.java
@@ -45,7 +45,7 @@ public class CommitController {
             @PathVariable("commitId") Long commitId) {
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(commitService.getCommit(docId, commitId));
+                .body(commitService.getCommit(docId, commitId, userDetails.getId()));
     }
 
     @GetMapping("/api/document/{docId}/merge")

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -142,7 +142,8 @@ public class CommitService {
     }
 
     @Transactional
-    public CreateCommitResponse mergeCommit(Long docId, MergeCommitRequest mergeRequest) {
+    public CreateCommitResponse mergeCommit(Long docId, MergeCommitRequest mergeRequest,
+            Long userId) {
         /**
          * Block을 저장하고
          * CommitSequence를 저장하고
@@ -157,9 +158,14 @@ public class CommitService {
             // 문서가 존재하는지 검사
             Doc doc = docService.getById(docId);
             // 브랜치가 존재하는지 검사
-            checkBranch(mergeRequest.baseBranchId(), mergeRequest.targetBranchId());
-            Branch baseBranch = branchService.getById(mergeRequest.baseBranchId());
-            Branch targetBranch = branchService.getById(mergeRequest.targetBranchId());
+            Long baseBranchId = mergeRequest.baseBranchId();
+            Long targetBranchId = mergeRequest.targetBranchId();
+
+            checkBranch(baseBranchId, targetBranchId);
+            Branch baseBranch = branchService.getById(baseBranchId);
+            Branch targetBranch = branchService.getById(targetBranchId);
+            branchService.checkBranchInDocOwnedByUser(docId, baseBranchId, userId);
+            branchService.checkBranchInDocOwnedByUser(docId, targetBranchId, userId);
 
             // Block과 Cbs를 저장
             commitMongoIds = saveBlockAndSequence(mergeRequest.content());

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -144,15 +144,7 @@ public class CommitService {
     @Transactional
     public CreateCommitResponse mergeCommit(Long docId, MergeCommitRequest mergeRequest,
             Long userId) {
-        /**
-         * Block을 저장하고
-         * CommitSequence를 저장하고
-         *
-         * Commit을 생성하고
-         * Commit에 CommitSequence의 _id를 저장하고
-         * 간선을 2개 저장하고
-         * baseBranch의 leaf를 업데이트
-         */
+
         CommitMongoIdsDto commitMongoIds = null;
         try {
             // 문서가 존재하는지 검사

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -127,7 +127,7 @@ public class CommitService {
         branchService.checkDocByIdAndUserId(docId, userId);
         List<Map<String, Object>> assemble = getWholeContent(commitId);
 
-        return new CommitResponse(assemble);
+        return CommitMapper.toCommitResponse(assemble);
     }
 
     @Transactional(readOnly = true)
@@ -138,7 +138,7 @@ public class CommitService {
         List<Map<String, Object>> baseContent = getWholeContent(baseId);
         List<Map<String, Object>> targetContent = getWholeContent(targetId);
 
-        return new CompareMergeCommitResponse(baseContent, targetContent);
+        return CommitMapper.toCompareMergeCommitResponse(baseContent, targetContent);
     }
 
     @Transactional

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -54,13 +54,16 @@ public class CommitService {
     private final CommitContentAssembler assembler;
 
     @Transactional(rollbackFor = Exception.class)
-    public CreateCommitResponse createCommit(Long docId, CreateCommitRequest commitRequest) {
+    public CreateCommitResponse createCommit(Long docId,
+            CreateCommitRequest commitRequest,
+            Long userId) {
 
         try {
             // * 1. documentId로 문서가 존재하는지 검사(JPA)
             Doc doc = docService.getById(docId);
             // * 2. commitRequest의 branchId로 브랜치가 존재하는지 검사(JPA)
             Branch branch = branchService.getById(commitRequest.branchId());
+            branchService.checkBranchInDocOwnedByUser(docId, commitRequest.branchId(), userId);
 
             // * 3. Commit Entity만들어서 DB에 저장
             Commit savedCommit = saveCommit(branch, commitRequest);

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -124,7 +124,7 @@ public class CommitService {
     @Transactional(readOnly = true)
     public CommitResponse getCommit(Long docId, Long commitId, Long userId) {
 
-        branchService.checkDocByIdAndUserId(docId, userId);
+        docService.checkDocByIdAndUserId(docId, userId);
         List<Map<String, Object>> assemble = getWholeContent(commitId);
 
         return CommitMapper.toCommitResponse(assemble);
@@ -134,7 +134,7 @@ public class CommitService {
     public CompareMergeCommitResponse compareCommitForMerge(Long docId, Long baseId, Long targetId,
             Long userId) {
 
-        branchService.checkDocByIdAndUserId(docId, userId);
+        docService.checkDocByIdAndUserId(docId, userId);
         List<Map<String, Object>> baseContent = getWholeContent(baseId);
         List<Map<String, Object>> targetContent = getWholeContent(targetId);
 

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -59,11 +59,11 @@ public class CommitService {
             Long userId) {
 
         try {
+            branchService.checkBranchInDocOwnedByUser(docId, commitRequest.branchId(), userId);
             // * 1. documentId로 문서가 존재하는지 검사(JPA)
             Doc doc = docService.getById(docId);
             // * 2. commitRequest의 branchId로 브랜치가 존재하는지 검사(JPA)
             Branch branch = branchService.getById(commitRequest.branchId());
-            branchService.checkBranchInDocOwnedByUser(docId, commitRequest.branchId(), userId);
 
             // * 3. Commit Entity만들어서 DB에 저장
             Commit savedCommit = saveCommit(branch, commitRequest);
@@ -148,16 +148,17 @@ public class CommitService {
         CommitMongoIdsDto commitMongoIds = null;
         try {
             // 문서가 존재하는지 검사
-            Doc doc = docService.getById(docId);
             // 브랜치가 존재하는지 검사
             Long baseBranchId = mergeRequest.baseBranchId();
             Long targetBranchId = mergeRequest.targetBranchId();
 
             checkBranch(baseBranchId, targetBranchId);
-            Branch baseBranch = branchService.getById(baseBranchId);
-            Branch targetBranch = branchService.getById(targetBranchId);
             branchService.checkBranchInDocOwnedByUser(docId, baseBranchId, userId);
             branchService.checkBranchInDocOwnedByUser(docId, targetBranchId, userId);
+
+            Doc doc = docService.getById(docId);
+            Branch baseBranch = branchService.getById(baseBranchId);
+            Branch targetBranch = branchService.getById(targetBranchId);
 
             // Block과 Cbs를 저장
             commitMongoIds = saveBlockAndSequence(mergeRequest.content());

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -131,10 +131,10 @@ public class CommitService {
     }
 
     @Transactional(readOnly = true)
-    public CompareMergeCommitResponse compareCommitForMerge(Long docId, Long baseId,
-            Long targetId) {
+    public CompareMergeCommitResponse compareCommitForMerge(Long docId, Long baseId, Long targetId,
+            Long userId) {
 
-        docService.notFoundDocCheck(docId);
+        branchService.checkDocByIdAndUserId(docId, userId);
         List<Map<String, Object>> baseContent = getWholeContent(baseId);
         List<Map<String, Object>> targetContent = getWholeContent(targetId);
 

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -122,9 +122,9 @@ public class CommitService {
     }
 
     @Transactional(readOnly = true)
-    public CommitResponse getCommit(Long docId, Long commitId) {
+    public CommitResponse getCommit(Long docId, Long commitId, Long userId) {
 
-        docService.notFoundDocCheck(docId);
+        branchService.checkDocByIdAndUserId(docId, userId);
         List<Map<String, Object>> assemble = getWholeContent(commitId);
 
         return new CommitResponse(assemble);

--- a/src/main/java/io/ejangs/docsa/domain/commit/util/CommitMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/util/CommitMapper.java
@@ -3,8 +3,12 @@ package io.ejangs.docsa.domain.commit.util;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dto.request.CreateCommitRequest;
 import io.ejangs.docsa.domain.commit.dto.request.MergeCommitRequest;
+import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
+import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
+import java.util.List;
+import java.util.Map;
 
 public class CommitMapper {
 
@@ -35,5 +39,14 @@ public class CommitMapper {
 
     public static CreateCommitResponse toCreateCommitResponse(Commit commit) {
         return new CreateCommitResponse(commit.getId());
+    }
+
+    public static CommitResponse toCommitResponse(List<Map<String, Object>> content) {
+        return new CommitResponse(content);
+    }
+
+    public static CompareMergeCommitResponse toCompareMergeCommitResponse(
+            List<Map<String, Object>> base, List<Map<String, Object>> target) {
+        return new CompareMergeCommitResponse(base, target);
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -223,8 +223,8 @@ public class DocService {
                 .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
     }
 
-    public void checkDocByIdAndUserId(Long documentId, Long userId) {
-        if (!docRepository.existsByIdAndUserId(documentId, userId)) {
+    public void checkDocByIdAndUserId(Long docId, Long userId) {
+        if (!docRepository.existsByIdAndUserId(docId, userId)) {
             throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
         }
     }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
@@ -30,6 +30,7 @@ import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.save.app.SaveService;
 import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.BlockSequenceErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
@@ -84,6 +85,7 @@ class CommitServiceMockTest {
     private Commit savedCommit;
     private CreateCommitResponse expectedResponse;
     private Edge edge;
+    private CustomUserDetails userDetails;
 
     @BeforeEach
     void setUp() {
@@ -102,6 +104,7 @@ class CommitServiceMockTest {
 
         // User 생성
         user = CommitMockTestUtils.createUser();
+        userDetails = CustomUserDetails.from(user);
 
         // Doc 생성
         doc = CommitMockTestUtils.createDoc(user);
@@ -160,7 +163,7 @@ class CommitServiceMockTest {
 
             // When
             CreateCommitResponse result = commitService.createCommit(docId,
-                    createCommitRequest);
+                    createCommitRequest, userDetails.getId());
 
             // Then
             assertThat(result).isEqualTo(expectedResponse);
@@ -196,7 +199,7 @@ class CommitServiceMockTest {
 
             // When
             CreateCommitResponse result = commitService.createCommit(docId,
-                    createCommitRequest);
+                    createCommitRequest, userDetails.getId());
 
             // Then
             assertThat(result).isEqualTo(expectedResponse);
@@ -231,7 +234,7 @@ class CommitServiceMockTest {
 
             // When
             CreateCommitResponse result = commitService.createCommit(docId,
-                    createCommitRequest);
+                    createCommitRequest, userDetails.getId());
 
             // Then
             assertThat(result).isEqualTo(expectedResponse);
@@ -248,7 +251,8 @@ class CommitServiceMockTest {
                 .when(docService).getById(docId);
 
         // When & Then
-        assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest))
+        assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
         verify(docService).getById(docId);
@@ -273,7 +277,8 @@ class CommitServiceMockTest {
             when(commitRepository.save(savedCommit)).thenReturn(savedCommit);
 
             // When & Then
-            assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest))
+            assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest,
+                    userDetails.getId()))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage(CommitErrorCode.FAIL_CREATE_COMMIT.getMessage());
 
@@ -303,7 +308,8 @@ class CommitServiceMockTest {
                     new RuntimeException("Block save failed"));
 
             // When & Then
-            assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest))
+            assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest,
+                    userDetails.getId()))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage(CommitErrorCode.FAIL_CREATE_COMMIT.getMessage());
 
@@ -335,7 +341,8 @@ class CommitServiceMockTest {
             when(commitRepository.save(savedCommit)).thenReturn(savedCommit);
 
             // When & Then
-            assertThatThrownBy(() -> commitService.createCommit(docId, invalidRequest))
+            assertThatThrownBy(() -> commitService.createCommit(docId, invalidRequest,
+                    userDetails.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(
                             BlockSequenceErrorCode.BLOCK_SEQUENCE_INVALID.getMessage());

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
@@ -42,6 +42,9 @@ class GetCommitMockTest {
     private BranchService branchService;
 
     @Mock
+    private DocService docService;
+
+    @Mock
     private CommitContentAssembler assembler;
 
     @InjectMocks
@@ -93,7 +96,7 @@ class GetCommitMockTest {
         assertThat(response).isNotNull();
         assertThat(response.content()).isEqualTo(mockContent);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler).assemble(commitMongoId);
     }
@@ -111,7 +114,7 @@ class GetCommitMockTest {
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler, never()).assemble(any());
     }
@@ -124,13 +127,13 @@ class GetCommitMockTest {
         Long commitId = 1L;
 
         doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
-                .when(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+                .when(docService).checkDocByIdAndUserId(docId, userDetails.getId());
 
         // when & then
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }
@@ -162,7 +165,7 @@ class GetCommitMockTest {
         assertThat(response.base()).isEqualTo(baseContent);
         assertThat(response.target()).isEqualTo(targetContent);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -184,7 +187,7 @@ class GetCommitMockTest {
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository, never()).findById(targetId);
         verify(assembler, never()).assemble(any());
@@ -210,7 +213,7 @@ class GetCommitMockTest {
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -225,14 +228,14 @@ class GetCommitMockTest {
         Long targetId = 2L;
 
         doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
-                .when(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+                .when(docService).checkDocByIdAndUserId(docId, userDetails.getId());
 
         // when & then
         assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import io.ejangs.docsa.domain.branch.app.BranchService;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
@@ -19,7 +20,7 @@ import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import io.ejangs.docsa.global.exception.CustomException;
-import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +39,7 @@ class GetCommitMockTest {
     private CommitRepository commitRepository;
 
     @Mock
-    private DocService docService;
+    private BranchService branchService;
 
     @Mock
     private CommitContentAssembler assembler;
@@ -92,7 +93,7 @@ class GetCommitMockTest {
         assertThat(response).isNotNull();
         assertThat(response.content()).isEqualTo(mockContent);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler).assemble(commitMongoId);
     }
@@ -110,7 +111,7 @@ class GetCommitMockTest {
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler, never()).assemble(any());
     }
@@ -122,14 +123,14 @@ class GetCommitMockTest {
         Long docId = 999L;
         Long commitId = 1L;
 
-        doThrow(new CustomException(CommitErrorCode.COMMIT_NOT_FOUND))
-                .when(docService).notFoundDocCheck(docId);
+        doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
+                .when(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
 
         // when & then
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }
@@ -154,14 +155,14 @@ class GetCommitMockTest {
 
         // when
         CompareMergeCommitResponse response = commitService.compareCommitForMerge(docId, baseId,
-                targetId);
+                targetId, userDetails.getId());
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.base()).isEqualTo(baseContent);
         assertThat(response.target()).isEqualTo(targetContent);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -179,10 +180,11 @@ class GetCommitMockTest {
         given(commitRepository.findById(baseId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId))
+        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository, never()).findById(targetId);
         verify(assembler, never()).assemble(any());
@@ -204,10 +206,11 @@ class GetCommitMockTest {
         given(assembler.assemble(baseCommitMongoId)).willReturn(baseContent);
 
         // when & then
-        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId))
+        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -221,14 +224,15 @@ class GetCommitMockTest {
         Long baseId = 1L;
         Long targetId = 2L;
 
-        doThrow(new CustomException(CommitErrorCode.COMMIT_NOT_FOUND))
-                .when(docService).notFoundDocCheck(docId);
+        doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
+                .when(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
 
         // when & then
-        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId))
+        assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).notFoundDocCheck(docId);
+        verify(branchService).checkDocByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
@@ -17,6 +17,7 @@ import io.ejangs.docsa.domain.commit.util.CommitMockTestUtils;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
 import java.util.List;
@@ -51,11 +52,13 @@ class GetCommitMockTest {
     private Commit baseCommit;
     private Commit targetCommit;
     private List<Map<String, Object>> mockContent;
+    private CustomUserDetails userDetails;
 
     @BeforeEach
     void setUp() {
         // User 생성
         user = CommitMockTestUtils.createUser();
+        userDetails = CustomUserDetails.from(user);
 
         // Doc 생성
         doc = CommitMockTestUtils.createDoc(user);
@@ -83,7 +86,7 @@ class GetCommitMockTest {
         given(assembler.assemble(commitMongoId)).willReturn(mockContent);
 
         // when
-        CommitResponse response = commitService.getCommit(docId, commitId);
+        CommitResponse response = commitService.getCommit(docId, commitId, userDetails.getId());
 
         // then
         assertThat(response).isNotNull();
@@ -104,7 +107,7 @@ class GetCommitMockTest {
         given(commitRepository.findById(commitId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commitService.getCommit(docId, commitId))
+        assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
         verify(docService).notFoundDocCheck(docId);
@@ -123,7 +126,7 @@ class GetCommitMockTest {
                 .when(docService).notFoundDocCheck(docId);
 
         // when & then
-        assertThatThrownBy(() -> commitService.getCommit(docId, commitId))
+        assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
         verify(docService).notFoundDocCheck(docId);

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -17,6 +17,7 @@ import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.domain.user.security.CustomUserDetails;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.BranchErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.CommitErrorCode;
@@ -58,12 +59,14 @@ class MergeCommitIntegrationTest {
     private Commit baseCommit;
     private Commit targetCommit;
     private List<BlockDto> blockContent;
+    private CustomUserDetails userDetails;
 
     @BeforeEach
     void setUp() {
         // 테스트 사용자 생성
         testUser = CommitIntegrationTestUtils.createTestUser();
         userRepository.save(testUser);
+        userDetails = CustomUserDetails.from(testUser);
 
         // 테스트 문서 생성
         testDoc = CommitIntegrationTestUtils.createTestDoc(testUser);
@@ -101,7 +104,8 @@ class MergeCommitIntegrationTest {
                 CommitIntegrationTestUtils.createMergeCommitRequest(baseBranch, targetBranch);
 
         // when
-        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request);
+        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId());
 
         // then
         assertThat(response).isNotNull();
@@ -147,7 +151,8 @@ class MergeCommitIntegrationTest {
         );
 
         // when
-        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request);
+        CreateCommitResponse response = commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId());
 
         // then
         assertThat(response).isNotNull();
@@ -168,7 +173,8 @@ class MergeCommitIntegrationTest {
                 CommitIntegrationTestUtils.createMergeCommitRequest(baseBranch, targetBranch);
 
         // when & then
-        assertThatThrownBy(() -> commitService.mergeCommit(nonExistentDocId, request))
+        assertThatThrownBy(() -> commitService.mergeCommit(nonExistentDocId, request,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(DocErrorCode.DOCUMENT_NOT_FOUND.getMessage());
     }
@@ -186,7 +192,8 @@ class MergeCommitIntegrationTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
     }
@@ -204,7 +211,8 @@ class MergeCommitIntegrationTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
     }
@@ -225,7 +233,8 @@ class MergeCommitIntegrationTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(CommitErrorCode.COMMIT_NOT_FOUND.getMessage());
     }
@@ -243,7 +252,8 @@ class MergeCommitIntegrationTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request))
+        assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
+                userDetails.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(CommitErrorCode.COMMIT_BAD_REQUEST.getMessage());
     }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -176,7 +176,7 @@ class MergeCommitIntegrationTest {
         assertThatThrownBy(() -> commitService.mergeCommit(nonExistentDocId, request,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class)
-                .hasMessageContaining(DocErrorCode.DOCUMENT_NOT_FOUND.getMessage());
+                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND_OR_FORBIDDEN.getMessage());
     }
 
     @Test
@@ -195,7 +195,7 @@ class MergeCommitIntegrationTest {
         assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class)
-                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
+                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND_OR_FORBIDDEN.getMessage());
     }
 
     @Test
@@ -214,7 +214,7 @@ class MergeCommitIntegrationTest {
         assertThatThrownBy(() -> commitService.mergeCommit(testDoc.getId(), request,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class)
-                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND.getMessage());
+                .hasMessageContaining(BranchErrorCode.BRANCH_NOT_FOUND_OR_FORBIDDEN.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## 🛰️ Issue Number
- #103

## 🪐 작업 내용
Controller에서 `@AuthenticationPrincipal CustomUserDetails userDetails` 도입에 따라 `CommitService`에서 User관련 유효성 검사 로직을 추가했습니다.
- `BranchService`의 `checkDocByIdAndUserId`메서드 사용
- `BranchService`의 `checkBranchInDocOwnedByUser`메서드 사용
- Test 코드를 이에 맞춰 수정
- 현재 `checkDocByIdAndUserId`메서드는 해당 메서드가 속한 `BrachService`에 맞지 않는 `ErrorCode`를 보내주고 있습니다.
  - `throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);`
  - 추후에 User관련 유효성 검사 로직만 따로 분리하여 공통으로 사용하는게 좋을 수 있겠다는 생각도 들었습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?