### PR TITLE
Docs: 환경별 설정을 위한 application.yml 파일 분리

### DIFF
--- a/src/main/java/io/ejangs/docsa/global/init/TestUserInitializer.java
+++ b/src/main/java/io/ejangs/docsa/global/init/TestUserInitializer.java
@@ -4,11 +4,13 @@ import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@Profile("local")
 @RequiredArgsConstructor
 public class TestUserInitializer {
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/docsa
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+server:
+  port: 8080
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${MYSQL_PROD_URL}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+server:
+  port: 8080
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    servers:
+      - url: http://ec2-3-34-159-207.ap-northeast-2.compute.amazonaws.com:8080
+        description: Production Server

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,5 +25,5 @@ springdoc:
     path: /swagger-ui.html
     enabled: true
     servers:
-      - url: http://ec2-3-34-159-207.ap-northeast-2.compute.amazonaws.com:8080
+      - url: ${SWAGGER_SERVER_URL}
         description: Production Server

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,14 @@ spring:
 
 server:
   port: 8080
+  ssl:
+    enabled: false
+  forward-headers-strategy: framework
+  servlet:
+    session:
+      cookie:
+        secure: true
+        same-site: None
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,6 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/docsa
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
+  profiles:
+    active: local
 
   data:
     mongodb:
@@ -14,8 +11,6 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-    hibernate:
-      ddl-auto: create-drop
 
   mail:
     host: smtp.gmail.com
@@ -39,7 +34,7 @@ spring:
       - passCodeCache
       - pwdResetCodeCache
     caffeine:
-      spec: maximumSize=10000, expireAfterWrite=3m
+      spec: maximumSize=10000, expireAfterWrite=4m
 
 auth:
   signup-code-cache-name: signupCodeCache

--- a/src/test/java/io/ejangs/docsa/DocsaApplicationTests.java
+++ b/src/test/java/io/ejangs/docsa/DocsaApplicationTests.java
@@ -5,11 +5,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.context.ActiveProfiles;
 
 @EnableAsync
 @EnableRetry
 @EnableScheduling
 @SpringBootTest
+@ActiveProfiles("test")
 class DocsaApplicationTests {
 
     @Test

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/MergeCommitIntegrationTest.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class MergeCommitIntegrationTest {
 
     @Autowired

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -44,6 +44,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +52,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DocServiceIntegrationTests {
 

--- a/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/save/app/SaveServiceIntegrationTest.java
@@ -29,11 +29,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SaveServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoDeleteRetryServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoDeleteRetryServiceTest.java
@@ -26,11 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MongoDeleteRetryServiceTest {
 

--- a/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTests.java
+++ b/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoTransactionTests.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MongoTransactionTests {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,7 +39,7 @@ spring:
       - signupCodeCache
       - passCodeCache
     caffeine:
-      spec: maximumSize=10000, expireAfterWrite=3m
+      spec: maximumSize=10000, expireAfterWrite=4m
 
 auth:
   signup-code-cache-name: signupCodeCache


### PR DESCRIPTION
## 🛰️ Issue Number
- #105 

## 🪐 작업 내용
- 환경별 설정을 위해 application.yml 파일을 분리했습니다.
- application.yml에는 공통 설정 및 지정할 활성화할 프로파일이 들어갑니다.
- application-local/prod에는 환경별 데이터베이스 및 스웨거 등의 개별 설정 내용이 들어갑니다.

추가적으로 test 패키지 내의 application.yml 파일 이름을 application-test.yml로 변경하고, 필요한 테스트에 `@ActiveProfiles("test")`를 추가했습니다. 
명시적으로 test를 붙여주기 전에는 테스트 시에도 기본 yml파일을 인식하여 ddl-auto로 인한 테스트 실패 문제가 발생하였고 이를 해결하기 위해 application-test.yml로 변경했습니다. 
Spring 컨텍스트를 로딩하는 테스트들에는 `@ActiveProfiles("test")`를 명시해서 테스트 환경 분리하였고, 이제는 설정에 따라 됐다 안됐다 하던 테스트들도 잘 됩니다! (아마..🥹)

빌드 시에도 문제 없어서 현재 dev 기준으로 다시 배포했습니다~
올라와있는 PR들 Merge되면 한번 더 배포하겠습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?