### PR TITLE
Fix: Commit 생성시 SaveId가 삭제되지 않는 문제

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/entity/Branch.java
@@ -108,4 +108,8 @@ public class Branch extends BaseEntity {
     public void removeCommit(Commit commit) {
         this.commits.remove(commit);
     }
+
+    public void removeSave() {
+        this.save = null;
+    }
 }

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -76,7 +76,7 @@ public class CommitService {
         branch.initializeRootCommitIfNull(savedCommit);
 
         // * 4. branchId를 기반으로 Save가 있다면 삭제
-        String saveMongoId = saveService.deleteSaveIfExists(branch.getId());
+        String saveMongoId = saveService.deleteSaveIfExists(branch);
 
         // * 5. 변경 전 Commit이 어떤 것인지 branch의 데이터를 통해 찾기(JPA - 지연로딩)
         Commit baseCommit = getBaseCommit(branch);
@@ -263,7 +263,7 @@ public class CommitService {
         edgeService.saveEdge(edge2);
 
         baseBranch.updateLeafCommit(savedCommit);
-        String saveMongoId = saveService.deleteSaveIfExists(baseBranch.getId());
+        String saveMongoId = saveService.deleteSaveIfExists(baseBranch);
         RenewUpdatedAtHelper.touch(baseBranch);
 
         branchService.saveBranch(baseBranch);

--- a/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/app/SaveService.java
@@ -75,6 +75,7 @@ public class SaveService {
         }
 
         RenewUpdatedAtHelper.touch(findSave);
+        branch.removeSave();
         saveRepository.delete(findSave);
         try {
             saveContentRepository.deleteById(findSave.getSaveMongoId());
@@ -94,9 +95,14 @@ public class SaveService {
                 .orElseThrow(() -> new CustomException(SaveErrorCode.SAVE_NOT_FOUND));
     }
 
-    public String deleteSaveIfExists(Long branchId) {
-        Save save = saveRepository.findByBranchId(branchId).orElse(null);
-        return save != null ? save.getSaveMongoId() : null;
+    public String deleteSaveIfExists(Branch branch) {
+        Save save = saveRepository.findByBranchId(branch.getId()).orElse(null);
+        branch.removeSave();
+        String saveMongoId = save != null ? save.getSaveMongoId() : null;
+        if (save != null) {
+            saveRepository.delete(save);
+        }
+        return saveMongoId;
     }
 
     private Save getValidSave(SaveIdentifierDto dto) {

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
@@ -207,7 +207,7 @@ class CommitServiceMockTest {
 
             // Then
             assertThat(result).isEqualTo(expectedResponse);
-            verify(saveService).deleteSaveIfExists(branch.getId());
+            verify(saveService).deleteSaveIfExists(branch);
         }
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
- #131

## 🪐 작업 내용
- Save 삭제시 Branch에서 Save와의 연관관계가 끊어지지 않아 그래프 조회시 saveId가 그대로 남아있는 문제를 해결했습니다.
- Commit을 생성할 때 이외에도 Save만 삭제하는 API에서도 같은 문제가 발생할 것이라 예측되어 같이 수정했습니다.
  - 현재 이슈와 다른 얘기지만 deleteSave에서 SaveContent를 삭제할 때 이벤트 리스너로 넘길 수 있을 것 같습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?