### PR TITLE
Fix:  doc컬렉션에서 branch삭제 추가, 그래프dto 쿼리 수정 

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -13,6 +13,7 @@ import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dao.mysql.EdgeRepository;
+import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
@@ -209,7 +210,11 @@ public class BranchService {
         // 6. 브랜치가 속한 문서의 수정시간 갱신
         RenewUpdatedAtHelper.touch(branch);
 
-        // 7. 브랜치, 나머지 RDB  브랜치 메타데이터 CASCADE 삭제
+        // 7. Doc의 branch 컬렉션에서 branch 수동 삭제
+        Doc doc = branch.getDoc();
+        doc.getBranches().remove(branch);
+
+        // 8. 브랜치, 나머지 RDB  브랜치 메타데이터 CASCADE 삭제
         branchRepository.delete(branch);
 
     }

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
@@ -11,12 +11,20 @@ import java.util.List;
 public interface BranchRepository extends JpaRepository<Branch, Long> {
 
     @Query("""
-                SELECT new io.ejangs.docsa.domain.doc.dto.graph.GraphBranchDto(
-                    b.id, b.name, b.createdAt, b.fromCommit.id, b.rootCommit.id, b.leafCommit.id, b.save.id
-                )
-                FROM Branch b
-                WHERE b.doc.id = :docId
-            """)
+    SELECT new io.ejangs.docsa.domain.doc.dto.graph.GraphBranchDto(
+        b.id,
+        b.name,
+        b.createdAt,
+        b.fromCommit.id,
+        b.rootCommit.id,
+        b.leafCommit.id,
+        (
+            SELECT s.id FROM Save s WHERE s.branch.id = b.id
+        )
+    )
+    FROM Branch b
+    WHERE b.doc.id = :docId
+""")
     List<GraphBranchDto> findBranchesByDocId(@Param("docId") Long docId);
 
     boolean existsByIdAndDocIdAndDocUserId(Long branchId, Long documentId, Long userId);

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CreateCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CreateCommitIntegrationTest.java
@@ -22,15 +22,18 @@ import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.mongo.deletion.util.MongoIdsCollector;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 public class CreateCommitIntegrationTest {
 
@@ -82,8 +85,9 @@ public class CreateCommitIntegrationTest {
         testUser = CommitIntegrationTestUtils.createTestUser();
         userRepository.save(testUser);
 
-        TestDocIntegrationDto dto = CommitIntegrationTestUtils
-                .createDocumentForIntegrationTest(testUser, cbsRepository, blockRepository);
+        TestDocIntegrationDto dto =
+                CommitIntegrationTestUtils.createDocumentForIntegrationTest(testUser, cbsRepository,
+                        blockRepository);
 
         testDoc = dto.doc();
         baseBranch = dto.baseBranch();
@@ -96,8 +100,8 @@ public class CreateCommitIntegrationTest {
 
         docRepository.save(testDoc);
 
-        TestCreateCommitRequestDto commitRequestDto = CommitIntegrationTestUtils
-                .createCommitRequestDto();
+        TestCreateCommitRequestDto commitRequestDto =
+                CommitIntegrationTestUtils.createCommitRequestDto();
 
         blocks = commitRequestDto.blocks();
         blockOrders = commitRequestDto.blockOrders();
@@ -107,19 +111,17 @@ public class CreateCommitIntegrationTest {
     @DisplayName("정상적인 Commit 생성 테스트")
     void create_Commit_Success() throws Exception {
 
-        CreateCommitRequest request = new CreateCommitRequest("title1",
-                "description1",
-                baseBranch.getId(),
-                blocks,
-                blockOrders);
+        CreateCommitRequest request =
+                new CreateCommitRequest("title1", "description1", baseBranch.getId(), blocks,
+                        blockOrders);
 
-        CreateCommitResponse response = commitService
-                .createCommit(testDoc.getId(), request, testUser.getId());
+        CreateCommitResponse response =
+                commitService.createCommit(testDoc.getId(), request, testUser.getId());
 
         System.out.println("response = " + response);
 
-        CommitResponse commit = commitService
-                .getCommit(testDoc.getId(), response.id(), testUser.getId());
+        CommitResponse commit =
+                commitService.getCommit(testDoc.getId(), response.id(), testUser.getId());
 
         System.out.println("commit = " + commit);
     }
@@ -128,18 +130,17 @@ public class CreateCommitIntegrationTest {
     @DisplayName("정상적인 최초 Commit 생성 테스트")
     void create_Init_Commit_Success() throws Exception {
 
-        TestInitDocIntegrationDto dto = CommitIntegrationTestUtils
-                .createInitDocumentForIntegrationTest(testUser, saveContentRepository);
+        TestInitDocIntegrationDto dto =
+                CommitIntegrationTestUtils.createInitDocumentForIntegrationTest(testUser,
+                        saveContentRepository);
         Branch main = dto.mainBranch();
         Doc doc = docRepository.save(dto.doc());
 
-        CreateCommitRequest request = new CreateCommitRequest("title1",
-                "description1",
-                main.getId(),
-                blocks,
-                blockOrders);
+        CreateCommitRequest request =
+                new CreateCommitRequest("title1", "description1", main.getId(), blocks,
+                        blockOrders);
 
-        CreateCommitResponse response = commitService
-                .createCommit(doc.getId(), request, testUser.getId());
+        CreateCommitResponse response =
+                commitService.createCommit(doc.getId(), request, testUser.getId());
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/DeleteCommitIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/DeleteCommitIntegrationTest.java
@@ -29,9 +29,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 public class DeleteCommitIntegrationTest {
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
@@ -70,5 +70,11 @@ public class DocGraphIntegrationTest {
         assertThat(result).isNotNull();
         assertThat(result.getTitle()).isEqualTo("브랜치 2개 있는 문서임당");
         assertThat(result.getBranches().size()).isEqualTo(2);
+        assertThat(result.getEdges()).hasSize(3);
+        long totalCommits = result.getBranches().stream()
+                .mapToLong(branch -> branch.getCommits().size())
+                .sum();
+        assertThat(totalCommits).isEqualTo(4);
+
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
@@ -1,8 +1,4 @@
-package io.ejangs.docsa.domain.doc.service;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+package io.ejangs.docsa.domain.doc.integration;
 
 import io.ejangs.docsa.domain.block.dao.mongodb.BlockRepository;
 import io.ejangs.docsa.domain.commit.dao.mongodb.CommitBlockSequenceRepository;
@@ -13,7 +9,6 @@ import io.ejangs.docsa.domain.doc.util.DocTestUtils;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +17,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DocGraphIntegrationTest {
@@ -52,8 +52,8 @@ public class DocGraphIntegrationTest {
         user = DocTestUtils.createUser();
         ReflectionTestUtils.setField(user, "id", 1L);
 
-        DocTestUtils.stubSaveMethodsForForkedBranchScenario(
-                blockRepository, commitBlockSequenceRepository, saveContentRepository);
+        DocTestUtils.stubSaveMethodsForForkedBranchScenario(blockRepository,
+                commitBlockSequenceRepository, saveContentRepository);
     }
 
     @Test
@@ -71,9 +71,8 @@ public class DocGraphIntegrationTest {
         assertThat(result.getTitle()).isEqualTo("브랜치 2개 있는 문서임당");
         assertThat(result.getBranches().size()).isEqualTo(2);
         assertThat(result.getEdges()).hasSize(3);
-        long totalCommits = result.getBranches().stream()
-                .mapToLong(branch -> branch.getCommits().size())
-                .sum();
+        long totalCommits =
+                result.getBranches().stream().mapToLong(branch -> branch.getCommits().size()).sum();
         assertThat(totalCommits).isEqualTo(4);
 
     }

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
@@ -1,73 +1,74 @@
-package io.ejangs.docsa.domain.doc.integration;
+package io.ejangs.docsa.domain.doc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import io.ejangs.docsa.domain.block.dao.mongodb.BlockRepository;
 import io.ejangs.docsa.domain.commit.dao.mongodb.CommitBlockSequenceRepository;
+import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.util.DocTestUtils;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
-import io.ejangs.docsa.global.security.WithCustomMockUser;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest
-@WithCustomMockUser
-@AutoConfigureMockMvc(addFilters = false)
-@Transactional
+@ExtendWith(MockitoExtension.class)
 public class DocGraphIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
 
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
+    @Mock
     private DocRepository docRepository;
 
-    @Autowired
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private SaveContentRepository saveContentRepository;
 
-    @Autowired
+    @Mock
     private CommitBlockSequenceRepository commitBlockSequenceRepository;
 
-    @Autowired
+    @Mock
     private BlockRepository blockRepository;
 
+    @InjectMocks
+    private DocService docService;
+
+    private User user;
+
+    @BeforeEach
+    void setup() {
+        user = DocTestUtils.createUser();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        DocTestUtils.stubSaveMethodsForForkedBranchScenario(
+                blockRepository, commitBlockSequenceRepository, saveContentRepository);
+    }
 
     @Test
-    @WithCustomMockUser
-    @DisplayName("그래프 조회 정상")
-    void createDocAndCommitsAndSave_thenGraphReflectsAll() throws Exception {
-        // given
-        User user = DocTestUtils.createUser();
-        ReflectionTestUtils.setField(user, "id", 1L);
-        userRepository.save(user);
+    @DisplayName("그래프 데이터 가져오기 테스트")
+    void testGetDocumentGraph() throws Exception {
 
         Doc doc = DocTestUtils.createForkedBranchScenario(user, saveContentRepository,
                 commitBlockSequenceRepository, blockRepository);
-        docRepository.save(doc);
 
-        // when & then
-        mockMvc.perform(get("/api/document/" + doc.getId() + "/graph")).andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("브랜치 2개 있는 문서임당"))
-                .andExpect(jsonPath("$.branches").isArray())
-                .andExpect(jsonPath("$.branches.length()").value(1))
-                .andExpect(jsonPath("$.commits").isArray())
-                .andExpect(jsonPath("$.commits.length()").value(4))
-                .andExpect(jsonPath("$.edges").isArray())
-                .andExpect(jsonPath("$.edges.length()").value(3));
+        when(docRepository.findById(doc.getId())).thenReturn(Optional.of(doc));
+
+        Doc result = docService.getById(doc.getId());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("브랜치 2개 있는 문서임당");
+        assertThat(result.getBranches().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
@@ -30,6 +30,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 public class DocTestUtils {
 
     public static List<Doc> createDocList(int count, User user) {
@@ -294,9 +297,6 @@ public class DocTestUtils {
         save.updateSaveMongoId(saveContent.getId());
         fork.setSave(save);
 
-        doc.addBranch(main);
-        doc.addBranch(fork);
-
         Edge edge1 = Edge.builder()
                 .doc(doc)
                 .prevCommit(commit1)
@@ -317,7 +317,40 @@ public class DocTestUtils {
 
         return doc;
     }
+    public static void stubSaveMethodsForForkedBranchScenario(
+            BlockRepository blockRepository,
+            CommitBlockSequenceRepository commitBlockSequenceRepository,
+            SaveContentRepository saveContentRepository) {
 
+        when(blockRepository.save(any(Block.class))).thenAnswer(invocation -> {
+            Block block = invocation.getArgument(0);
+            if (block.getId() == null) {
+                ReflectionTestUtils.setField(block, "id", String.valueOf(generateUniqueId()));
+            }
+            return block;
+        });
+
+        when(commitBlockSequenceRepository.save(any(CommitBlockSequence.class))).thenAnswer(invocation -> {
+            CommitBlockSequence seq = invocation.getArgument(0);
+            if (seq.getId() == null) {
+                ReflectionTestUtils.setField(seq, "id", "mockSeqId-" + generateUniqueId());
+            }
+            return seq;
+        });
+
+        when(saveContentRepository.save(any(SaveContent.class))).thenAnswer(invocation -> {
+            SaveContent saveContent = invocation.getArgument(0);
+            if (saveContent.getId() == null) {
+                ReflectionTestUtils.setField(saveContent, "id", "mockSaveId-" + generateUniqueId());
+            }
+            return saveContent;
+        });
+    }
+    private static long uniqueIdCounter = 1000L;
+
+    private static synchronized long generateUniqueId() {
+        return uniqueIdCounter++;
+    }
 
     public static Page<DocListResponse> convertToDocListResponsePage(List<Doc> docs,
             Pageable pageable) {


### PR DESCRIPTION
## 🛰️ Issue Number
- #133 

## 🪐 작업 내용

- 그래프 조회를 위해 dto projection을 하던 중 save 삭제 기능 추가로, save.id가 null일 때 연관관계  b.save.id를 가져오지 못해 쿼리 전체가 결과 없음 반환 -> save에 대해선 서브쿼리를 따로 작성해 서브쿼리의 결과과 0개면 null을 반환하도록 수정
```java
      List<GraphBranchDto> branches = branchRepository.findBranchesByDocId(documentId);

```
```java
    @Query("""
    SELECT new io.ejangs.docsa.domain.doc.dto.graph.GraphBranchDto(
        b.id,
        b.name,
        b.createdAt,
        b.fromCommit.id,
        b.rootCommit.id,
        b.leafCommit.id,
        (
            SELECT s.id FROM Save s WHERE s.branch.id = b.id
        )
    )
    FROM Branch b
    WHERE b.doc.id = :docId
""")
    List<GraphBranchDto> findBranchesByDocId(@Param("docId") Long docId);
```

- Doc 컬렉션에서 삭제할 branch를 직접 삭제
- 브랜치 삭제시 BranchService에 다음을 추가함

```java
     // 7. Doc의 branch 컬렉션에서 branch 수동 삭제
        Doc doc = branch.getDoc();
        doc.getBranches().remove(branch);
```

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?