### PR TITLE
Docs: doc 리스트 메인, 사이드바, 제목검색 Swagger Schema 수정

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListResponse.java
@@ -1,0 +1,42 @@
+package io.ejangs.docsa.domain.doc.dto.swagger;
+import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "문서 목록 페이지 응답 (DocListResponse 기반)")
+public class PageDocListResponse {
+
+    @Schema(description = "문서 목록")
+    private List<DocListResponse> content;
+
+    @Schema(description = "페이지 정보")
+    private PageableSchema pageable;
+
+    @Schema(description = "마지막 페이지 여부")
+    private boolean last;
+
+    @Schema(description = "총 페이지 수")
+    private int totalPages;
+
+    @Schema(description = "총 요소 개수")
+    private long totalElements;
+
+    @Schema(description = "첫 번째 페이지 여부")
+    private boolean first;
+
+    @Schema(description = "현재 페이지 크기")
+    private int size;
+
+    @Schema(description = "현재 페이지 번호")
+    private int number;
+
+    @Schema(description = "정렬 정보")
+    private SortSchema sort;
+
+    @Schema(description = "현재 페이지 요소 개수")
+    private int numberOfElements;
+
+    @Schema(description = "페이지가 비어있는지 여부")
+    private boolean empty;
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListSimpleResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListSimpleResponse.java
@@ -1,0 +1,43 @@
+package io.ejangs.docsa.domain.doc.dto.swagger;
+
+import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "문서 목록의 페이지 응답")
+public class PageDocListSimpleResponse {
+
+    @Schema(description = "문서 목록")
+    private List<DocListSimpleResponse> content;
+
+    @Schema(description = "페이지 정보")
+    private PageableSchema pageable;
+
+    @Schema(description = "마지막 페이지 여부")
+    private boolean last;
+
+    @Schema(description = "총 페이지 수")
+    private int totalPages;
+
+    @Schema(description = "총 요소 개수")
+    private long totalElements;
+
+    @Schema(description = "첫 번째 페이지 여부")
+    private boolean first;
+
+    @Schema(description = "현재 페이지 크기")
+    private int size;
+
+    @Schema(description = "현재 페이지 번호")
+    private int number;
+
+    @Schema(description = "정렬 정보")
+    private SortSchema sort;
+
+    @Schema(description = "현재 페이지 요소 개수")
+    private int numberOfElements;
+
+    @Schema(description = "페이지가 비어있는지 여부")
+    private boolean empty;
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageableSchema.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageableSchema.java
@@ -1,0 +1,26 @@
+package io.ejangs.docsa.domain.doc.dto.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "페이지 요청 정보")
+public class PageableSchema {
+
+    @Schema(description = "페이지 번호")
+    private int pageNumber;
+
+    @Schema(description = "페이지 크기")
+    private int pageSize;
+
+    @Schema(description = "오프셋")
+    private long offset;
+
+    @Schema(description = "페이징 여부")
+    private boolean paged;
+
+    @Schema(description = "비페이징 여부")
+    private boolean unpaged;
+
+    @Schema(description = "정렬 정보")
+    private SortSchema sort;
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/SortSchema.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/SortSchema.java
@@ -1,0 +1,17 @@
+package io.ejangs.docsa.domain.doc.dto.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "정렬 정보")
+public class SortSchema {
+
+    @Schema(description = "정렬이 비어있는지 여부")
+    private boolean empty;
+
+    @Schema(description = "정렬되었는지 여부")
+    private boolean sorted;
+
+    @Schema(description = "정렬되지 않았는지 여부")
+    private boolean unsorted;
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocListDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocListDocs.java
@@ -1,7 +1,6 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -55,7 +54,7 @@ import org.springframework.http.MediaType;
                         responseCode = "200",
                         description = "문서 목록 조회 성공",
                         content = @Content(
-                                schema = @Schema(implementation = PageDocListSimpleResponse.class),
+                                schema = @Schema(implementation = PageDocListResponse.class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                                 examples = @ExampleObject(
                                         value = """

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocListDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocListDocs.java
@@ -1,6 +1,7 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
 import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
+import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -54,7 +55,7 @@ import org.springframework.http.MediaType;
                         responseCode = "200",
                         description = "문서 목록 조회 성공",
                         content = @Content(
-                                schema = @Schema(implementation = DocListResponse.class),
+                                schema = @Schema(implementation = PageDocListSimpleResponse.class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                                 examples = @ExampleObject(
                                         value = """

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocSidebarListDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocSidebarListDocs.java
@@ -1,6 +1,7 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
 import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -54,7 +55,7 @@ import org.springframework.http.MediaType;
                         responseCode = "200",
                         description = "사이드바 문서 목록 조회 성공",
                         content = @Content(
-                                schema = @Schema(implementation = DocListSimpleResponse.class),
+                                schema = @Schema(implementation = PageDocListSimpleResponse.class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                                 examples = @ExampleObject(
                                         value = """

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocSidebarListDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/GetDocSidebarListDocs.java
@@ -1,6 +1,5 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
 import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/SearchDocDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/SearchDocDocs.java
@@ -1,6 +1,6 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
-import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,135 +9,195 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import org.springframework.http.MediaType;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Operation(summary = "문서 제목 검색", description = """
-        로그인한 사용자의 문서 중 제목에 해당 키워드가 포함된 문서를 검색합니다.
-        검색 결과는 페이지네이션 및 정렬 조건(`sort`, `order`)에 따라 반환됩니다.
-        기본 정렬 필드는 `updatedAt`, 정렬 순서는 `desc`입니다.
-        """, parameters = {
-        @Parameter(name = "keyword", description = "검색할 키워드", example = "기획서", required = true,
-                in = ParameterIn.QUERY),
-        @Parameter(name = "sort", description = "정렬 기준 필드 (예: updatedAt, createdAt)",
-                example = "updatedAt", in = ParameterIn.QUERY),
-        @Parameter(name = "order", description = "정렬 순서 (asc 또는 desc)", example = "desc",
-                in = ParameterIn.QUERY),
-        @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0",
-                in = ParameterIn.QUERY),
-        @Parameter(name = "size", description = "페이지 크기", example = "10", in = ParameterIn.QUERY)},
-        responses = {@ApiResponse(responseCode = "200", description = "문서 검색 성공",
-                content = @Content(
-                        schema = @Schema(implementation = PageDocListSimpleResponse.class),
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        examples = @ExampleObject(value = """
-                                {
-                                    "content": [
-                                        {
-                                            "id": 3,
-                                            "title": "9월 기획서",
-                                            "createdAt": "2025-07-24T23:08:36.088612+09:00",
-                                            "updatedAt": "2025-07-24T23:08:36.114375+09:00",
-                                            "preview": "미리보기 없음",
-                                            "recent": {
-                                                "recentType": "SAVE",
-                                                "recentTypeId": 3
-                                            }
-                                        },
-                                        {
-                                            "id": 2,
-                                            "title": "6월 기획서",
-                                            "createdAt": "2025-07-24T23:08:32.066607+09:00",
-                                            "updatedAt": "2025-07-24T23:08:32.088371+09:00",
-                                            "preview": "미리보기 없음",
-                                            "recent": {
-                                                "recentType": "SAVE",
-                                                "recentTypeId": 2
-                                            }
-                                        },
-                                        {
-                                            "id": 1,
-                                            "title": "5월 기획서",
-                                            "createdAt": "2025-07-24T23:08:27.511586+09:00",
-                                            "updatedAt": "2025-07-24T23:08:27.648299+09:00",
-                                            "preview": "미리보기 없음",
-                                            "recent": {
-                                                "recentType": "SAVE",
-                                                "recentTypeId": 1
-                                            }
-                                        }
-                                    ],
-                                    "pageable": {
-                                        "pageNumber": 0,
-                                        "pageSize": 10,
-                                        "sort": {
-                                            "empty": false,
-                                            "sorted": true,
-                                            "unsorted": false
-                                        },
-                                        "offset": 0,
-                                        "paged": true,
-                                        "unpaged": false
-                                    },
-                                    "last": true,
-                                    "totalElements": 3,
-                                    "totalPages": 1,
-                                    "first": true,
-                                    "size": 10,
-                                    "number": 0,
-                                    "sort": {
-                                        "empty": false,
-                                        "sorted": true,
-                                        "unsorted": false
-                                    },
-                                    "numberOfElements": 3,
-                                    "empty": false
+@Operation(
+        summary = "문서 제목 검색",
+        description = """
+                로그인한 사용자의 문서 중 제목에 해당 키워드가 포함된 문서를 검색합니다.
+                검색 결과는 페이지네이션 및 정렬 조건(`sort`, `order`)에 따라 반환됩니다.
+                기본 정렬 필드는 `updatedAt`, 정렬 순서는 `desc`입니다.
+                """,
+        parameters = {
+                @Parameter(
+                        name = "keyword",
+                        description = "검색할 키워드",
+                        example = "기획서",
+                        required = true,
+                        in = ParameterIn.QUERY
+                ),
+                @Parameter(
+                        name = "sort",
+                        description = "정렬 기준 필드 (예: updatedAt, createdAt)",
+                        example = "updatedAt",
+                        in = ParameterIn.QUERY
+                ),
+                @Parameter(
+                        name = "order",
+                        description = "정렬 순서 (asc 또는 desc)",
+                        example = "desc",
+                        in = ParameterIn.QUERY
+                ),
+                @Parameter(
+                        name = "page",
+                        description = "페이지 번호 (0부터 시작)",
+                        example = "0",
+                        in = ParameterIn.QUERY
+                ),
+                @Parameter(
+                        name = "size",
+                        description = "페이지 크기",
+                        example = "10",
+                        in = ParameterIn.QUERY
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "문서 검색 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = PageDocListResponse.class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                examples = @ExampleObject(
+                                        value = """
+                                                {
+                                                    "content": [
+                                                        {
+                                                            "id": 3,
+                                                            "title": "9월 기획서",
+                                                            "createdAt": "2025-07-24T23:08:36.088612+09:00",
+                                                            "updatedAt": "2025-07-24T23:08:36.114375+09:00",
+                                                            "preview": "미리보기 없음",
+                                                            "recent": {
+                                                                "recentType": "SAVE",
+                                                                "recentTypeId": 3
+                                                            }
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "title": "6월 기획서",
+                                                            "createdAt": "2025-07-24T23:08:32.066607+09:00",
+                                                            "updatedAt": "2025-07-24T23:08:32.088371+09:00",
+                                                            "preview": "미리보기 없음",
+                                                            "recent": {
+                                                                "recentType": "SAVE",
+                                                                "recentTypeId": 2
+                                                            }
+                                                        },
+                                                        {
+                                                            "id": 1,
+                                                            "title": "5월 기획서",
+                                                            "createdAt": "2025-07-24T23:08:27.511586+09:00",
+                                                            "updatedAt": "2025-07-24T23:08:27.648299+09:00",
+                                                            "preview": "미리보기 없음",
+                                                            "recent": {
+                                                                "recentType": "SAVE",
+                                                                "recentTypeId": 1
+                                                            }
+                                                        }
+                                                    ],
+                                                    "pageable": {
+                                                        "pageNumber": 0,
+                                                        "pageSize": 10,
+                                                        "sort": {
+                                                            "empty": false,
+                                                            "sorted": true,
+                                                            "unsorted": false
+                                                        },
+                                                        "offset": 0,
+                                                        "paged": true,
+                                                        "unpaged": false
+                                                    },
+                                                    "last": true,
+                                                    "totalElements": 3,
+                                                    "totalPages": 1,
+                                                    "first": true,
+                                                    "size": 10,
+                                                    "number": 0,
+                                                    "sort": {
+                                                        "empty": false,
+                                                        "sorted": true,
+                                                        "unsorted": false
+                                                    },
+                                                    "numberOfElements": 3,
+                                                    "empty": false
+                                                }
+                                                """
+                                )
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "정렬 실패 - 정렬 옵션이 잘못됨",
+                        content = @Content(
+                                schema = @Schema(implementation = ErrorResponse.class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                examples = {
+                                        @ExampleObject(
+                                                name = "정렬 기준이 잘못됨",
+                                                value = """
+                                                        {
+                                                             "status": 400,
+                                                             "message": "지원하지 않는 정렬 기준입니다.",
+                                                             "error": "UNSUPPORTED_SORT_TYPE"
+                                                         }
+                                                        """),
+                                        @ExampleObject(
+                                                name = "정렬 방향이 잘못됨",
+                                                value = """
+                                                        {
+                                                              "status": 400,
+                                                              "message": "지원하지 않는 정렬 방향입니다.",
+                                                              "error": "UNSUPPORTED_DIRECTION_TYPE"
+                                                        }
+                                                        """),
+                                        @ExampleObject(
+                                                name = "페이지 크기가 잘못됨",
+                                                value = """
+                                                        {
+                                                            "status": 400,
+                                                            "message": "페이지 크기는 0 이상이어야 합니다.",
+                                                            "error": "INVALID_PAGE_SIZE"
+                                                        }
+                                                        """),
+                                        @ExampleObject(
+                                                name = "페이지 번호가 잘못됨",
+                                                value = """
+                                                        {
+                                                            "status": 400,
+                                                            "message": "페이지 번호는 0 이상이어야 합니다.",
+                                                            "error": "INVALID_PAGE"
+                                                        }
+                                                        """
+                                        )
                                 }
-                                """))),
-                @ApiResponse(responseCode = "400", description = "정렬 실패 - 정렬 옵션이 잘못됨",
-                        content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패 - 로그인 세션이 없음",
+                        content = @Content(
+                                schema = @Schema(implementation = ErrorResponse.class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                examples = {@ExampleObject(name = "정렬 기준이 잘못됨", value = """
-                                        {
-                                             "status": 400,
-                                             "message": "지원하지 않는 정렬 기준입니다.",
-                                             "error": "UNSUPPORTED_SORT_TYPE"
-                                         }
-                                        """), @ExampleObject(name = "정렬 방향이 잘못됨", value = """
-                                        {
-                                              "status": 400,
-                                              "message": "지원하지 않는 정렬 방향입니다.",
-                                              "error": "UNSUPPORTED_DIRECTION_TYPE"
-                                        }
-                                        """), @ExampleObject(name = "페이지 크기가 잘못됨", value = """
-                                        {
-                                            "status": 400,
-                                            "message": "페이지 크기는 0 이상이어야 합니다.",
-                                            "error": "INVALID_PAGE_SIZE"
-                                        }
-                                        """), @ExampleObject(name = "페이지 번호가 잘못됨", value = """
-                                        {
-                                            "status": 400,
-                                            "message": "페이지 번호는 0 이상이어야 합니다.",
-                                            "error": "INVALID_PAGE"
-                                        }
-                                        """)})),
-                @ApiResponse(responseCode = "401", description = "인증 실패 - 로그인 세션이 없음",
-                        content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                examples = @ExampleObject(value = """
-                                        {
-                                            "status": 401,
-                                            "message": "로그인이 필요합니다.",
-                                            "error": "LOGIN_REQUIRED"
-                                        }
-                                        """)))})
+                                examples = @ExampleObject(
+                                        value = """
+                                                {
+                                                    "status": 401,
+                                                    "message": "로그인이 필요합니다.",
+                                                    "error": "LOGIN_REQUIRED"
+                                                }
+                                                """
+                                )
+                        )
+                )
+        }
+)
 public @interface SearchDocDocs {
 
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/swagger/SearchDocDocs.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/swagger/SearchDocDocs.java
@@ -1,6 +1,6 @@
 package io.ejangs.docsa.domain.doc.swagger;
 
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
+import io.ejangs.docsa.domain.doc.dto.swagger.PageDocListSimpleResponse;
 import io.ejangs.docsa.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,195 +9,135 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Operation(
-        summary = "문서 제목 검색",
-        description = """
-                로그인한 사용자의 문서 중 제목에 해당 키워드가 포함된 문서를 검색합니다.
-                검색 결과는 페이지네이션 및 정렬 조건(`sort`, `order`)에 따라 반환됩니다.
-                기본 정렬 필드는 `updatedAt`, 정렬 순서는 `desc`입니다.
-                """,
-        parameters = {
-                @Parameter(
-                        name = "keyword",
-                        description = "검색할 키워드",
-                        example = "기획서",
-                        required = true,
-                        in = ParameterIn.QUERY
-                ),
-                @Parameter(
-                        name = "sort",
-                        description = "정렬 기준 필드 (예: updatedAt, createdAt)",
-                        example = "updatedAt",
-                        in = ParameterIn.QUERY
-                ),
-                @Parameter(
-                        name = "order",
-                        description = "정렬 순서 (asc 또는 desc)",
-                        example = "desc",
-                        in = ParameterIn.QUERY
-                ),
-                @Parameter(
-                        name = "page",
-                        description = "페이지 번호 (0부터 시작)",
-                        example = "0",
-                        in = ParameterIn.QUERY
-                ),
-                @Parameter(
-                        name = "size",
-                        description = "페이지 크기",
-                        example = "10",
-                        in = ParameterIn.QUERY
-                )
-        },
-        responses = {
-                @ApiResponse(
-                        responseCode = "200",
-                        description = "문서 검색 성공",
-                        content = @Content(
-                                schema = @Schema(implementation = DocListResponse.class),
-                                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                examples = @ExampleObject(
-                                        value = """
-                                                {
-                                                    "content": [
-                                                        {
-                                                            "id": 3,
-                                                            "title": "9월 기획서",
-                                                            "createdAt": "2025-07-24T23:08:36.088612+09:00",
-                                                            "updatedAt": "2025-07-24T23:08:36.114375+09:00",
-                                                            "preview": "미리보기 없음",
-                                                            "recent": {
-                                                                "recentType": "SAVE",
-                                                                "recentTypeId": 3
-                                                            }
-                                                        },
-                                                        {
-                                                            "id": 2,
-                                                            "title": "6월 기획서",
-                                                            "createdAt": "2025-07-24T23:08:32.066607+09:00",
-                                                            "updatedAt": "2025-07-24T23:08:32.088371+09:00",
-                                                            "preview": "미리보기 없음",
-                                                            "recent": {
-                                                                "recentType": "SAVE",
-                                                                "recentTypeId": 2
-                                                            }
-                                                        },
-                                                        {
-                                                            "id": 1,
-                                                            "title": "5월 기획서",
-                                                            "createdAt": "2025-07-24T23:08:27.511586+09:00",
-                                                            "updatedAt": "2025-07-24T23:08:27.648299+09:00",
-                                                            "preview": "미리보기 없음",
-                                                            "recent": {
-                                                                "recentType": "SAVE",
-                                                                "recentTypeId": 1
-                                                            }
-                                                        }
-                                                    ],
-                                                    "pageable": {
-                                                        "pageNumber": 0,
-                                                        "pageSize": 10,
-                                                        "sort": {
-                                                            "empty": false,
-                                                            "sorted": true,
-                                                            "unsorted": false
-                                                        },
-                                                        "offset": 0,
-                                                        "paged": true,
-                                                        "unpaged": false
-                                                    },
-                                                    "last": true,
-                                                    "totalElements": 3,
-                                                    "totalPages": 1,
-                                                    "first": true,
-                                                    "size": 10,
-                                                    "number": 0,
-                                                    "sort": {
-                                                        "empty": false,
-                                                        "sorted": true,
-                                                        "unsorted": false
-                                                    },
-                                                    "numberOfElements": 3,
-                                                    "empty": false
-                                                }
-                                                """
-                                )
-                        )
-                ),
-                @ApiResponse(
-                        responseCode = "400",
-                        description = "정렬 실패 - 정렬 옵션이 잘못됨",
-                        content = @Content(
-                                schema = @Schema(implementation = ErrorResponse.class),
-                                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                examples = {
-                                        @ExampleObject(
-                                                name = "정렬 기준이 잘못됨",
-                                                value = """
-                                                        {
-                                                             "status": 400,
-                                                             "message": "지원하지 않는 정렬 기준입니다.",
-                                                             "error": "UNSUPPORTED_SORT_TYPE"
-                                                         }
-                                                        """),
-                                        @ExampleObject(
-                                                name = "정렬 방향이 잘못됨",
-                                                value = """
-                                                        {
-                                                              "status": 400,
-                                                              "message": "지원하지 않는 정렬 방향입니다.",
-                                                              "error": "UNSUPPORTED_DIRECTION_TYPE"
-                                                        }
-                                                        """),
-                                        @ExampleObject(
-                                                name = "페이지 크기가 잘못됨",
-                                                value = """
-                                                        {
-                                                            "status": 400,
-                                                            "message": "페이지 크기는 0 이상이어야 합니다.",
-                                                            "error": "INVALID_PAGE_SIZE"
-                                                        }
-                                                        """),
-                                        @ExampleObject(
-                                                name = "페이지 번호가 잘못됨",
-                                                value = """
-                                                        {
-                                                            "status": 400,
-                                                            "message": "페이지 번호는 0 이상이어야 합니다.",
-                                                            "error": "INVALID_PAGE"
-                                                        }
-                                                        """
-                                        )
+@Operation(summary = "문서 제목 검색", description = """
+        로그인한 사용자의 문서 중 제목에 해당 키워드가 포함된 문서를 검색합니다.
+        검색 결과는 페이지네이션 및 정렬 조건(`sort`, `order`)에 따라 반환됩니다.
+        기본 정렬 필드는 `updatedAt`, 정렬 순서는 `desc`입니다.
+        """, parameters = {
+        @Parameter(name = "keyword", description = "검색할 키워드", example = "기획서", required = true,
+                in = ParameterIn.QUERY),
+        @Parameter(name = "sort", description = "정렬 기준 필드 (예: updatedAt, createdAt)",
+                example = "updatedAt", in = ParameterIn.QUERY),
+        @Parameter(name = "order", description = "정렬 순서 (asc 또는 desc)", example = "desc",
+                in = ParameterIn.QUERY),
+        @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0",
+                in = ParameterIn.QUERY),
+        @Parameter(name = "size", description = "페이지 크기", example = "10", in = ParameterIn.QUERY)},
+        responses = {@ApiResponse(responseCode = "200", description = "문서 검색 성공",
+                content = @Content(
+                        schema = @Schema(implementation = PageDocListSimpleResponse.class),
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        examples = @ExampleObject(value = """
+                                {
+                                    "content": [
+                                        {
+                                            "id": 3,
+                                            "title": "9월 기획서",
+                                            "createdAt": "2025-07-24T23:08:36.088612+09:00",
+                                            "updatedAt": "2025-07-24T23:08:36.114375+09:00",
+                                            "preview": "미리보기 없음",
+                                            "recent": {
+                                                "recentType": "SAVE",
+                                                "recentTypeId": 3
+                                            }
+                                        },
+                                        {
+                                            "id": 2,
+                                            "title": "6월 기획서",
+                                            "createdAt": "2025-07-24T23:08:32.066607+09:00",
+                                            "updatedAt": "2025-07-24T23:08:32.088371+09:00",
+                                            "preview": "미리보기 없음",
+                                            "recent": {
+                                                "recentType": "SAVE",
+                                                "recentTypeId": 2
+                                            }
+                                        },
+                                        {
+                                            "id": 1,
+                                            "title": "5월 기획서",
+                                            "createdAt": "2025-07-24T23:08:27.511586+09:00",
+                                            "updatedAt": "2025-07-24T23:08:27.648299+09:00",
+                                            "preview": "미리보기 없음",
+                                            "recent": {
+                                                "recentType": "SAVE",
+                                                "recentTypeId": 1
+                                            }
+                                        }
+                                    ],
+                                    "pageable": {
+                                        "pageNumber": 0,
+                                        "pageSize": 10,
+                                        "sort": {
+                                            "empty": false,
+                                            "sorted": true,
+                                            "unsorted": false
+                                        },
+                                        "offset": 0,
+                                        "paged": true,
+                                        "unpaged": false
+                                    },
+                                    "last": true,
+                                    "totalElements": 3,
+                                    "totalPages": 1,
+                                    "first": true,
+                                    "size": 10,
+                                    "number": 0,
+                                    "sort": {
+                                        "empty": false,
+                                        "sorted": true,
+                                        "unsorted": false
+                                    },
+                                    "numberOfElements": 3,
+                                    "empty": false
                                 }
-                        )
-                ),
-                @ApiResponse(
-                        responseCode = "401",
-                        description = "인증 실패 - 로그인 세션이 없음",
-                        content = @Content(
-                                schema = @Schema(implementation = ErrorResponse.class),
+                                """))),
+                @ApiResponse(responseCode = "400", description = "정렬 실패 - 정렬 옵션이 잘못됨",
+                        content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                examples = @ExampleObject(
-                                        value = """
-                                                {
-                                                    "status": 401,
-                                                    "message": "로그인이 필요합니다.",
-                                                    "error": "LOGIN_REQUIRED"
-                                                }
-                                                """
-                                )
-                        )
-                )
-        }
-)
+                                examples = {@ExampleObject(name = "정렬 기준이 잘못됨", value = """
+                                        {
+                                             "status": 400,
+                                             "message": "지원하지 않는 정렬 기준입니다.",
+                                             "error": "UNSUPPORTED_SORT_TYPE"
+                                         }
+                                        """), @ExampleObject(name = "정렬 방향이 잘못됨", value = """
+                                        {
+                                              "status": 400,
+                                              "message": "지원하지 않는 정렬 방향입니다.",
+                                              "error": "UNSUPPORTED_DIRECTION_TYPE"
+                                        }
+                                        """), @ExampleObject(name = "페이지 크기가 잘못됨", value = """
+                                        {
+                                            "status": 400,
+                                            "message": "페이지 크기는 0 이상이어야 합니다.",
+                                            "error": "INVALID_PAGE_SIZE"
+                                        }
+                                        """), @ExampleObject(name = "페이지 번호가 잘못됨", value = """
+                                        {
+                                            "status": 400,
+                                            "message": "페이지 번호는 0 이상이어야 합니다.",
+                                            "error": "INVALID_PAGE"
+                                        }
+                                        """)})),
+                @ApiResponse(responseCode = "401", description = "인증 실패 - 로그인 세션이 없음",
+                        content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                examples = @ExampleObject(value = """
+                                        {
+                                            "status": 401,
+                                            "message": "로그인이 필요합니다.",
+                                            "error": "LOGIN_REQUIRED"
+                                        }
+                                        """)))})
 public @interface SearchDocDocs {
 
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #136 

## 🪐 작업 내용

Doc 도메인의 전체 문서 리스트 조회 - 메인화면, 전체 문서 리스트 조회 -사이드바, 문서 제목 검색 Swagger Schema 응답에서 페이지네이션임을 명시하고자 다음과 같이 수정하였습니다.

<img width="520" height="334" alt="image" src="https://github.com/user-attachments/assets/fa5b0238-37cb-435b-8be5-1f9c14086e77" />

<img width="527" height="332" alt="image" src="https://github.com/user-attachments/assets/11b0df4d-c756-4bac-861e-8ecf8e4034e2" />

<img width="521" height="332" alt="image" src="https://github.com/user-attachments/assets/baa78639-0685-4b8e-9cd4-d2f4836cc63c" />



## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?