### PR TITLE
Fix: 브랜치 생성시 이름 검증 에러처리 추가

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -302,13 +302,10 @@ public class BranchService {
     }
 
     private void checkDuplicatedWithBranchName(Long docId, String requestName) {
-        List<Branch> branches = branchRepository.findAllByDocId(docId);
-
-        boolean isDuplicate = branches.stream().anyMatch(branch -> branch.getName().equals(requestName));
+        boolean isDuplicate = branchRepository.existsByDocIdAndName(docId, requestName);
 
         if (isDuplicate) {
-                throw new CustomException(BranchErrorCode.BRANCH_NAME_DUPLICATED);
-
+            throw new CustomException(BranchErrorCode. BRANCH_NAME_DUPLICATED);
         }
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -305,7 +305,7 @@ public class BranchService {
         boolean isDuplicate = branchRepository.existsByDocIdAndName(docId, requestName);
 
         if (isDuplicate) {
-            throw new CustomException(BranchErrorCode. BRANCH_NAME_DUPLICATED);
+            throw new CustomException(BranchErrorCode.BRANCH_NAME_DUPLICATED);
         }
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -27,11 +27,9 @@ import io.ejangs.docsa.global.exception.errorcode.SaveErrorCode;
 import io.ejangs.docsa.global.mongo.deletion.dto.MongoIdsDto;
 import io.ejangs.docsa.global.mongo.deletion.util.MongoDeleteMapper;
 import io.ejangs.docsa.global.util.RenewUpdatedAtHelper;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -72,6 +70,8 @@ public class BranchService {
             Long userId) {
 
         checkDocByIdAndUserId(documentId, userId);
+
+        checkDuplicatedWithMainBranchName(documentId, request.name());
 
         Long fromCommitId = request.fromCommitId();
 
@@ -299,5 +299,15 @@ public class BranchService {
 
     public boolean checkFromOrRootCommitInBranch(Commit commit) {
         return branchRepository.existsByRootCommitIdOrFromCommitId(commit.getId());
+    }
+
+    private void checkDuplicatedWithMainBranchName(Long docId, String requestName) {
+        Optional<Branch> mainBranchOpt = branchRepository.findMainBranchByDocumentId(docId);
+        if (mainBranchOpt.isPresent()) {
+            String mainBranchName = mainBranchOpt.get().getName();
+            if (mainBranchName.equals(requestName)) {
+                throw new CustomException(BranchErrorCode.MAIN_BRANCH_NAME_DUPLICATED);
+            }
+        }
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -71,8 +71,6 @@ public class BranchService {
 
         checkDocByIdAndUserId(documentId, userId);
 
-        checkDuplicatedWithBranchName(documentId, request.name());
-
         Long fromCommitId = request.fromCommitId();
 
         // 1. fromCommitId가 null이면 최초 브랜치 생성 시도 -> 여기서는 허용하지 않음
@@ -104,6 +102,8 @@ public class BranchService {
 
         } else {
             // 중간 커밋에서 작업을 이어가는 경우 → 새로운 브랜치를 생성하고 저장도 함께 생성
+            checkDuplicatedWithBranchName(documentId, request.name());
+
             Branch newBranch = Branch.builder().name(request.name()).doc(fromBranch.getDoc())
                     .fromCommit(fromCommit).build();
 

--- a/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/app/BranchService.java
@@ -71,7 +71,7 @@ public class BranchService {
 
         checkDocByIdAndUserId(documentId, userId);
 
-        checkDuplicatedWithMainBranchName(documentId, request.name());
+        checkDuplicatedWithBranchName(documentId, request.name());
 
         Long fromCommitId = request.fromCommitId();
 
@@ -301,13 +301,14 @@ public class BranchService {
         return branchRepository.existsByRootCommitIdOrFromCommitId(commit.getId());
     }
 
-    private void checkDuplicatedWithMainBranchName(Long docId, String requestName) {
-        Optional<Branch> mainBranchOpt = branchRepository.findMainBranchByDocumentId(docId);
-        if (mainBranchOpt.isPresent()) {
-            String mainBranchName = mainBranchOpt.get().getName();
-            if (mainBranchName.equals(requestName)) {
-                throw new CustomException(BranchErrorCode.MAIN_BRANCH_NAME_DUPLICATED);
-            }
+    private void checkDuplicatedWithBranchName(Long docId, String requestName) {
+        List<Branch> branches = branchRepository.findAllByDocId(docId);
+
+        boolean isDuplicate = branches.stream().anyMatch(branch -> branch.getName().equals(requestName));
+
+        if (isDuplicate) {
+                throw new CustomException(BranchErrorCode.BRANCH_NAME_DUPLICATED);
+
         }
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
@@ -39,6 +39,6 @@ public interface BranchRepository extends JpaRepository<Branch, Long> {
             """)
     boolean existsByRootCommitIdOrFromCommitId(@Param("commitId") Long commitId);
 
-    List<Branch> findAllByDocId(Long docId);
+    boolean existsByDocIdAndName(Long docId, String name);
 }
 

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface BranchRepository extends JpaRepository<Branch, Long> {
 
@@ -40,7 +39,6 @@ public interface BranchRepository extends JpaRepository<Branch, Long> {
             """)
     boolean existsByRootCommitIdOrFromCommitId(@Param("commitId") Long commitId);
 
-    @Query("SELECT b FROM Branch b WHERE b.doc.id = :documentId AND b.fromCommit IS NULL")
-    Optional<Branch> findMainBranchByDocumentId(Long documentId);
+    List<Branch> findAllByDocId(Long docId);
 }
 

--- a/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/branch/dao/mysql/BranchRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BranchRepository extends JpaRepository<Branch, Long> {
 
@@ -38,5 +39,8 @@ public interface BranchRepository extends JpaRepository<Branch, Long> {
                 ) THEN true ELSE false END
             """)
     boolean existsByRootCommitIdOrFromCommitId(@Param("commitId") Long commitId);
+
+    @Query("SELECT b FROM Branch b WHERE b.doc.id = :documentId AND b.fromCommit IS NULL")
+    Optional<Branch> findMainBranchByDocumentId(Long documentId);
 }
 

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
@@ -13,7 +13,7 @@ public enum BranchErrorCode implements ErrorCode {
     MAIN_BRANCH_FIX_UNAVAILABLE(HttpStatus.BAD_REQUEST, "메인 버전은 삭제 또는 수정할 수 없습니다", "MAIN_BRANCH_FIX_UNAVAILABLE"),
     SUB_BRANCH_DELETE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "서브 버전이 있어 해당 브랜치를 삭제할 수 없습니다", "SUB_BRANCH_DELETE_UNAVAILABLE"),
     BRANCH_DELETE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "해당 버전을 삭제할 수 없습니다", "BRANCH_DELETE_UNAVAILABLE"),
-    MAIN_BRANCH_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "새로운 버전의 이름이 메인 버전의 이름과 동일합니다", "MAIN_BRANCH_NAME_DUPLICATED");
+    BRANCH_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "새로운 버전의 이름은 다른 버전과 중복될 수 없습니다.", "BRANCH_NAME_DUPLICATED");
     private final HttpStatus status;
     private final String message;
     private final String error;

--- a/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
+++ b/src/main/java/io/ejangs/docsa/global/exception/errorcode/BranchErrorCode.java
@@ -12,8 +12,8 @@ public enum BranchErrorCode implements ErrorCode {
     BRANCH_NOT_FOUND_OR_FORBIDDEN(HttpStatus.NOT_FOUND, "해당 버전을 찾을 수 없습니다", "BRANCH_NOT_FOUND_OR_FORBIDDEN"),
     MAIN_BRANCH_FIX_UNAVAILABLE(HttpStatus.BAD_REQUEST, "메인 버전은 삭제 또는 수정할 수 없습니다", "MAIN_BRANCH_FIX_UNAVAILABLE"),
     SUB_BRANCH_DELETE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "서브 버전이 있어 해당 브랜치를 삭제할 수 없습니다", "SUB_BRANCH_DELETE_UNAVAILABLE"),
-    BRANCH_DELETE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "해당 버전을 삭제할 수 없습니다", "BRANCH_DELETE_UNAVAILABLE");
-
+    BRANCH_DELETE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "해당 버전을 삭제할 수 없습니다", "BRANCH_DELETE_UNAVAILABLE"),
+    MAIN_BRANCH_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "새로운 버전의 이름이 메인 버전의 이름과 동일합니다", "MAIN_BRANCH_NAME_DUPLICATED");
     private final HttpStatus status;
     private final String message;
     private final String error;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,4 +42,4 @@ auth:
   pwd-reset-code-cache-name: pwdResetCodeCache
 
 default:
-  branch: main
+  branch: default


### PR DESCRIPTION
## 🛰️ Issue Number
- #146 

## 🪐 작업 내용
브랜치 생성시에도 메인 브랜치와 이름이 같을 때 에러를 표시합니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?