### PR TITLE
Refactor: 문서 생성 보상트랜잭션 도입 / 명령-조회 서비스 책임분리 / 외 잔잔한 코드수정

### DIFF
--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -19,6 +19,7 @@ import io.ejangs.docsa.domain.commit.dto.response.CreateCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.commit.util.CommitBlockSequenceMapper;
 import io.ejangs.docsa.domain.commit.util.CommitMapper;
+import io.ejangs.docsa.domain.doc.app.DocQueryService;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.app.EdgeService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -52,6 +53,7 @@ public class CommitService {
     private final CommitBlockSequenceRepository cbsRepository;
 
     private final DocService docService;
+    private final DocQueryService docQueryService;
     private final BranchService branchService;
     private final BlockService blockService;
     private final SaveService saveService;
@@ -68,7 +70,7 @@ public class CommitService {
 
         branchService.checkBranchInDocOwnedByUser(docId, commitRequest.branchId(), userId);
         // * 1. documentId로 문서가 존재하는지 검사(JPA)
-        Doc doc = docService.getById(docId);
+        Doc doc = docQueryService.getById(docId);
         // * 2. commitRequest의 branchId로 브랜치가 존재하는지 검사(JPA)
         Branch branch = branchService.getById(commitRequest.branchId());
 
@@ -131,7 +133,7 @@ public class CommitService {
     @Transactional(readOnly = true)
     public CommitResponse getCommit(Long docId, Long commitId, Long userId) {
 
-        docService.checkDocByIdAndUserId(docId, userId);
+        docQueryService.checkByIdAndUserId(docId, userId);
         List<Map<String, Object>> assemble = getWholeContent(commitId);
 
         return CommitMapper.toCommitResponse(assemble);
@@ -141,7 +143,7 @@ public class CommitService {
     public CompareMergeCommitResponse compareCommitForMerge(Long docId, Long baseId, Long targetId,
             Long userId) {
 
-        docService.checkDocByIdAndUserId(docId, userId);
+        docQueryService.checkByIdAndUserId(docId, userId);
         List<Map<String, Object>> baseContent = getWholeContent(baseId);
         List<Map<String, Object>> targetContent = getWholeContent(targetId);
 
@@ -174,7 +176,7 @@ public class CommitService {
             branchService.checkBranchInDocOwnedByUser(docId, baseBranchId, userId);
             branchService.checkBranchInDocOwnedByUser(docId, targetBranchId, userId);
 
-            Doc doc = docService.getById(docId);
+            Doc doc = docQueryService.getById(docId);
 
             // Block과 Cbs를 저장
             commitMongoIds = saveBlockAndSequence(mergeRequest.content());
@@ -203,11 +205,9 @@ public class CommitService {
 
     @Transactional(rollbackFor = Exception.class)
     public void deleteCommit(Long docId, Long commitId, Long userId) {
-        //TODO Doc doc = getDocByIdAndUserId() 대체 가능
-        docService.checkDocByIdAndUserId(docId, userId);
+        Doc doc = docQueryService.getByIdAndUserId(docId, userId);
 
         Commit commit = getById(commitId);
-        Doc doc = docService.getById(docId);
         // LeafCommit일 경우에만 삭제 가능
         checkLeafCommit(commit);
         // 어느 브랜치의 FromCommit이나 RootCommit일 경우 삭제 불가능

--- a/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
+++ b/src/main/java/io/ejangs/docsa/domain/commit/app/CommitService.java
@@ -203,6 +203,7 @@ public class CommitService {
 
     @Transactional(rollbackFor = Exception.class)
     public void deleteCommit(Long docId, Long commitId, Long userId) {
+        //TODO Doc doc = getDocByIdAndUserId() 대체 가능
         docService.checkDocByIdAndUserId(docId, userId);
 
         Commit commit = getById(commitId);

--- a/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
@@ -65,7 +65,7 @@ public class DocController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getSimpleList(userDetails.getId(), pageable));
+                .body(docService.getSimplePage(userDetails.getId(), pageable));
     }
 
     @GetMapping

--- a/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/api/DocController.java
@@ -4,8 +4,8 @@ import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.swagger.CreateDocDocs;
 import io.ejangs.docsa.domain.doc.swagger.DeleteDocDocs;
@@ -54,7 +54,7 @@ public class DocController {
 
     @GetMapping("/sidebar")
     @GetDocSidebarListDocs
-    public ResponseEntity<Page<DocListSimpleResponse>> readListSidebar(
+    public ResponseEntity<Page<DocSimplePageResponse>> readListSidebar(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "updatedAt") String sort,
             @RequestParam(defaultValue = "desc") String order,
@@ -70,7 +70,7 @@ public class DocController {
 
     @GetMapping
     @GetDocListDocs
-    public ResponseEntity<Page<DocListResponse>> readList(
+    public ResponseEntity<Page<DocPageResponse>> readList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "updatedAt") String sort,
             @RequestParam(defaultValue = "desc") String order,
@@ -81,12 +81,12 @@ public class DocController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(docService.getList(userDetails.getId(), pageable));
+                .body(docService.getPage(userDetails.getId(), pageable));
     }
 
     @SearchDocDocs
     @GetMapping("/search")
-    public ResponseEntity<Page<DocListResponse>> search(
+    public ResponseEntity<Page<DocPageResponse>> search(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "") String keyword,
             @RequestParam(defaultValue = "updatedAt") String sort,

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
@@ -1,0 +1,45 @@
+package io.ejangs.docsa.domain.doc.app;
+
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
+import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
+import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
+import io.ejangs.docsa.domain.doc.entity.Doc;
+import io.ejangs.docsa.domain.doc.util.DocMapper;
+import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
+import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
+import io.ejangs.docsa.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DocCreateMySqlTxService {
+
+    private final DocQueryService docQueryService;
+
+    @Value("${default.branch}")
+    private String defaultBranchName;
+
+    @Transactional(rollbackFor = Exception.class)
+    public DocCreateResponse createMySqlPart(DocTitleRequest request, Long userId,
+            String saveContentId) {
+
+        User user = docQueryService.getUserOrThrow(userId);
+
+        String title = request.title();
+        docQueryService.checkTitleDuplicate(userId, title);
+
+        Doc doc = docQueryService.createDoc(user, title);
+        Branch defaultBranch = docQueryService.createDefaultBranch(doc, defaultBranchName);
+        Save defaultSave = docQueryService.createDefaultSave(defaultBranch, saveContentId);
+        return DocMapper.toCreateResponse(doc, defaultSave);
+    }
+
+
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
@@ -1,15 +1,10 @@
 package io.ejangs.docsa.domain.doc.app;
 
-import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
-import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
-import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.util.DocMapper;
-import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
 import io.ejangs.docsa.domain.save.entity.Save;
-import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +24,7 @@ public class DocCreateMySqlTxService {
     public DocCreateResponse createMySqlPart(String title, User user,
             String saveContentId) {
 
-        Doc doc = docQueryService.createDoc(user, title);
+        Doc doc = docQueryService.create(user, title);
         Branch defaultBranch = docQueryService.createDefaultBranch(doc, defaultBranchName);
         Save defaultSave = docQueryService.createDefaultSave(defaultBranch, saveContentId);
         return DocMapper.toCreateResponse(doc, defaultSave);

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateMySqlTxService.java
@@ -26,13 +26,8 @@ public class DocCreateMySqlTxService {
     private String defaultBranchName;
 
     @Transactional(rollbackFor = Exception.class)
-    public DocCreateResponse createMySqlPart(DocTitleRequest request, Long userId,
+    public DocCreateResponse createMySqlPart(String title, User user,
             String saveContentId) {
-
-        User user = docQueryService.getUserOrThrow(userId);
-
-        String title = request.title();
-        docQueryService.checkTitleDuplicate(userId, title);
 
         Doc doc = docQueryService.createDoc(user, title);
         Branch defaultBranch = docQueryService.createDefaultBranch(doc, defaultBranchName);

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateOrchestrator.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateOrchestrator.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DocCreateSagaService {
+public class DocCreateOrchestrator {
 
     private final SaveContentRepository saveContentRepository;
     private final DocCreateMySqlTxService docCreateMySqlTxService;

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
@@ -1,0 +1,45 @@
+package io.ejangs.docsa.domain.doc.app;
+
+import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
+import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
+import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
+import io.ejangs.docsa.domain.save.document.SaveContent;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.DatabaseErrorCode;
+import io.ejangs.docsa.global.mongo.deletion.app.MongoDeleteRetryService;
+import io.ejangs.docsa.global.mongo.deletion.entity.MongoDeleteFailure;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DocCreateSagaService {
+
+    private final SaveContentRepository saveContentRepository;
+    private final DocCreateMySqlTxService docCreateMySqlTxService;
+    private final MongoDeleteRetryService mongoDeleteRetryService;
+
+    public DocCreateResponse create(DocTitleRequest request, Long userId) {
+        // 문서 생성에 경우 SaveContent 1개의 문서만 insert하여 단일 문서 트랜잭션은 보장되어 별도의 트랜잭션 처리 필요없음.
+        // 다른 도메인에서는 다중 문서 트랜잭션을 위해 트랜잭션 설정 필요.
+        SaveContent defaultSaveContent = createDefaultSaveContent();
+        String saveContentId = defaultSaveContent.getId();
+
+        return docCreateMySqlTxService.createMySqlPart(request, userId, saveContentId);
+    }
+
+    private SaveContent createDefaultSaveContent() {
+        try {
+            return saveContentRepository.save(SaveContent.builder().build());
+        } catch (DataAccessException e) {
+            log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
+            throw new CustomException(DatabaseErrorCode.DATABASE_ERROR);
+        } catch (Exception e) {
+            log.error("DefaultSaveContent Mongo 알 수 없는 오류 - {}", e.getMessage(), e);
+            throw new CustomException(DatabaseErrorCode.DATABASE_ERROR);
+        }
+    }
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
@@ -1,9 +1,9 @@
 package io.ejangs.docsa.domain.doc.app;
 
-import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.save.document.SaveContent;
+import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DatabaseErrorCode;
 import io.ejangs.docsa.global.mongo.deletion.app.MongoDeleteRetryService;
@@ -22,14 +22,14 @@ public class DocCreateSagaService {
     private final DocCreateMySqlTxService docCreateMySqlTxService;
     private final MongoDeleteRetryService mongoDeleteRetryService;
 
-    public DocCreateResponse create(DocTitleRequest request, Long userId) {
+    public DocCreateResponse create(String title, User user) {
         // 문서 생성에 경우 SaveContent 1개의 문서만 insert하여 단일 문서 트랜잭션은 보장되어 별도의 트랜잭션 처리 필요없음.
         // 다른 도메인에서는 다중 문서 트랜잭션을 위해 트랜잭션 설정 필요.
         SaveContent defaultSaveContent = createDefaultSaveContent();
         String saveContentId = defaultSaveContent.getId();
 
         try {
-            return docCreateMySqlTxService.createMySqlPart(request, userId, saveContentId);
+            return docCreateMySqlTxService.createMySqlPart(title, user, saveContentId);
         } catch (Exception e) {
             log.warn("[SAGA] MYSQL 생성 실패 -> Mongo 보상 삭제. saveContentId = {}", saveContentId, e);
             compensateMongo(saveContentId);

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocCreateSagaService.java
@@ -7,7 +7,7 @@ import io.ejangs.docsa.domain.save.document.SaveContent;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DatabaseErrorCode;
 import io.ejangs.docsa.global.mongo.deletion.app.MongoDeleteRetryService;
-import io.ejangs.docsa.global.mongo.deletion.entity.MongoDeleteFailure;
+import io.ejangs.docsa.global.mongo.deletion.dto.MongoIdsDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -28,9 +28,22 @@ public class DocCreateSagaService {
         SaveContent defaultSaveContent = createDefaultSaveContent();
         String saveContentId = defaultSaveContent.getId();
 
-        return docCreateMySqlTxService.createMySqlPart(request, userId, saveContentId);
+        try {
+            return docCreateMySqlTxService.createMySqlPart(request, userId, saveContentId);
+        } catch (Exception e) {
+            log.warn("[SAGA] MYSQL 생성 실패 -> Mongo 보상 삭제. saveContentId = {}", saveContentId, e);
+            compensateMongo(saveContentId);
+            throw e;
+        }
     }
 
+    private void compensateMongo(String saveContentId) {
+        // 기존 삭제 파이프라인 재사용: @Retryable + @Recover(+ Failure 저장)
+        MongoIdsDto dto = MongoIdsDto.forSaveContent(saveContentId);
+        mongoDeleteRetryService.deleteMongoData(dto);
+    }
+
+    // save로 이동?
     private SaveContent createDefaultSaveContent() {
         try {
             return saveContentRepository.save(SaveContent.builder().build());

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
@@ -1,0 +1,63 @@
+package io.ejangs.docsa.domain.doc.app;
+
+import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
+import io.ejangs.docsa.domain.branch.entity.Branch;
+import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
+import io.ejangs.docsa.domain.doc.entity.Doc;
+import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
+import io.ejangs.docsa.domain.save.entity.Save;
+import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
+import io.ejangs.docsa.domain.user.entity.User;
+import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
+import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
+import io.ejangs.docsa.global.util.RenewUpdatedAtHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DocQueryService {
+
+    private final UserRepository userRepository;
+    private final DocRepository docRepository;
+    private final BranchRepository branchRepository;
+    private final SaveRepository saveRepository;
+
+    // 추후 User 도메인으로 이동 필요
+    public User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    }
+
+    // branch로 이동해도 좋을듯
+    public Branch createDefaultBranch(Doc doc, String defaultBranchName) {
+        Branch branch =
+                branchRepository.save(Branch.builder().name(defaultBranchName).doc(doc).build());
+        doc.addBranch(branch);
+        RenewUpdatedAtHelper.touch(branch);
+        return branch;
+    }
+
+    // save로 이동
+    public Save createDefaultSave(Branch branch, String mongoID) {
+        return saveRepository.save(Save.builder().branch(branch).saveMongoId(mongoID).build());
+    }
+
+
+    public Doc createDoc(User user, String title) {
+        Doc doc = docRepository.save(Doc.builder().title(title).user(user).build());
+        docRepository.flush();
+        user.addDocument(doc);
+        return doc;
+    }
+
+    public void checkTitleDuplicate(Long userId, String title) {
+        Boolean alreadyExistsTitle = docRepository.existsByUserIdAndTitle(userId, title);
+        if (alreadyExistsTitle) {
+            throw new CustomException(DocErrorCode.TITLE_DUPLICATION);
+        }
+    }
+
+}

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
@@ -4,6 +4,7 @@ import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.entity.Doc;
+import io.ejangs.docsa.domain.doc.util.DocListAssembler;
 import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
 import io.ejangs.docsa.domain.save.entity.Save;
 import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
@@ -13,7 +14,10 @@ import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import io.ejangs.docsa.global.util.RenewUpdatedAtHelper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,8 @@ public class DocQueryService {
     private final DocRepository docRepository;
     private final BranchRepository branchRepository;
     private final SaveRepository saveRepository;
+
+    private final DocListAssembler docListAssembler;
 
     // 추후 User 도메인으로 이동 필요
     public User getUserOrThrow(Long userId) {
@@ -58,6 +64,11 @@ public class DocQueryService {
         if (alreadyExistsTitle) {
             throw new CustomException(DocErrorCode.TITLE_DUPLICATION);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Doc> getAllDocPageByUserId(Long userId, Pageable pageable) {
+        return docRepository.findAllByUserId(userId, pageable);
     }
 
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
@@ -52,7 +52,7 @@ public class DocQueryService {
     }
 
 
-    public Doc createDoc(User user, String title) {
+    public Doc create(User user, String title) {
         Doc doc = docRepository.save(Doc.builder().title(title).user(user).build());
         docRepository.flush();
         user.addDocument(doc);
@@ -67,8 +67,31 @@ public class DocQueryService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Doc> getAllDocPageByUserId(Long userId, Pageable pageable) {
+    public Doc getById(Long id) {
+        return docRepository.findById(id)
+                .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Doc getByIdAndUserId(Long docId, Long userId) {
+        return docRepository.getDocByIdAndUserId(docId, userId)
+                .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    public void checkByIdAndUserId(Long docId, Long userId) {
+        if (!docRepository.existsByIdAndUserId(docId, userId)) {
+            throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Doc> getDocPageByUserId(Long userId, Pageable pageable) {
         return docRepository.findAllByUserId(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Doc> searchDoc(String keyword, Long userId, Pageable pageable) {
+        return docRepository.searchDocByTitle(keyword, userId, pageable);
     }
 
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocQueryService.java
@@ -85,12 +85,12 @@ public class DocQueryService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Doc> getDocPageByUserId(Long userId, Pageable pageable) {
+    public Page<Doc> getPageByUserId(Long userId, Pageable pageable) {
         return docRepository.findAllByUserId(userId, pageable);
     }
 
     @Transactional(readOnly = true)
-    public Page<Doc> searchDoc(String keyword, Long userId, Pageable pageable) {
+    public Page<Doc> searchByTitle(String keyword, Long userId, Pageable pageable) {
         return docRepository.searchDocByTitle(keyword, userId, pageable);
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -20,27 +20,18 @@ import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.doc.util.DocListAssembler;
 import io.ejangs.docsa.domain.doc.util.DocMapper;
 import io.ejangs.docsa.domain.doc.util.GraphMapper;
-import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
-import io.ejangs.docsa.domain.save.dao.mysql.SaveRepository;
-import io.ejangs.docsa.domain.save.document.SaveContent;
-import io.ejangs.docsa.domain.save.entity.Save;
-import io.ejangs.docsa.domain.user.dao.mysql.UserRepository;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.BranchErrorCode;
-import io.ejangs.docsa.global.exception.errorcode.DatabaseErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
-import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
 import io.ejangs.docsa.global.mongo.deletion.dto.MongoIdsDto;
 import io.ejangs.docsa.global.mongo.deletion.util.MongoIdsCollector;
-import io.ejangs.docsa.global.util.RenewUpdatedAtHelper;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -53,66 +44,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class DocService {
 
     private final DocRepository docRepository;
-    private final UserRepository userRepository;
     private final BranchRepository branchRepository;
-    private final SaveRepository saveRepository;
     private final CommitRepository commitRepository;
     private final EdgeRepository edgeRepository;
-    private final SaveContentRepository saveContentRepository;
+
+    private final DocQueryService docQueryService;
+    private final DocCreateSagaService docCreateSagaService;
+
     private final DocListAssembler docListAssembler;
     private final MongoIdsCollector mongoIdsCollector;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Value("${default.branch}")
-    private String defaultBranchName;
-
-    @Transactional(rollbackFor = Exception.class)
     public DocCreateResponse create(DocTitleRequest request, Long userId) {
 
-        User user = getUserOrThrow(userId);
-
-        String title = request.title();
-        checkTitleDuplicate(userId, title);
-
-        Doc doc = createDoc(user, title);
-        Branch defaultBranch = createDefaultBranch(doc);
-
-        Save defaultSave = Save.builder().branch(defaultBranch).build();
-
-        //Mongo 저장을 RDB 저장 이 후에 진행하여 실패시 예외 발생으로 인한 종료
-        //Mongo 저장실패 이종간 트랜잭션 고도화 필요
-        SaveContent defaultSaveContent = createDefaultSaveContent();
-
-        defaultSave.updateSaveMongoId(defaultSaveContent.getId());
-        Save save = saveRepository.save(defaultSave);
-        return DocMapper.toCreateResponse(doc, save);
-    }
-
-    private Doc createDoc(User user, String title) {
-        Doc doc = docRepository.save(Doc.builder().title(title).user(user).build());
-        docRepository.flush();
-        user.addDocument(doc);
-        return doc;
-    }
-
-    private Branch createDefaultBranch(Doc doc) {
-        Branch branch =
-                branchRepository.save(Branch.builder().name(defaultBranchName).doc(doc).build());
-        doc.addBranch(branch);
-        RenewUpdatedAtHelper.touch(branch);
-        return branch;
-    }
-
-    private SaveContent createDefaultSaveContent() {
-        try {
-            return saveContentRepository.save(SaveContent.builder().build());
-        } catch (DataAccessException e) {
-            log.error("DefaultSaveContent Mongo 저장 실패 - {}", e.getMessage(), e);
-            throw new CustomException(DatabaseErrorCode.DATABASE_ERROR);
-        } catch (Exception e) {
-            log.error("DefaultSaveContent Mongo 알 수 없는 오류 - {}", e.getMessage(), e);
-            throw new CustomException(DatabaseErrorCode.DATABASE_ERROR);
-        }
+        return docCreateSagaService.create(request, userId);
     }
 
     @Transactional(readOnly = true)
@@ -146,23 +91,12 @@ public class DocService {
             throw new CustomException(DocErrorCode.SAME_AS_CURRENT_TITLE);
         }
 
-        checkTitleDuplicate(userId, title);
+        docQueryService.checkTitleDuplicate(userId, title);
         doc.updateTitle(title);
 
         return DocMapper.toUpdateResponse(doc);
     }
 
-    private void checkTitleDuplicate(Long userId, String title) {
-        Boolean alreadyExistsTitle = docRepository.existsByUserIdAndTitle(userId, title);
-        if (alreadyExistsTitle) {
-            throw new CustomException(DocErrorCode.TITLE_DUPLICATION);
-        }
-    }
-
-    private User getUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-    }
 
     public Doc getDocByIdAndUserId(Long documentId, Long userId) {
         return docRepository.getDocByIdAndUserId(documentId, userId)
@@ -214,7 +148,7 @@ public class DocService {
 
     @Transactional
     public void delete(Long docId, Long userId) {
-        User user = getUserOrThrow(userId);
+        User user = docQueryService.getUserOrThrow(userId);
         Doc doc = getDocByIdAndUserId(docId, userId);
         List<Edge> edges = doc.getEdges();
         List<Branch> branches = doc.getBranches();
@@ -228,10 +162,4 @@ public class DocService {
         eventPublisher.publishEvent(docDeleteMongoIds);
     }
 
-    @Transactional(readOnly = true)
-    public void notFoundDocCheck(Long id) {
-        if (!docRepository.existsById(id)) {
-            throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
-        }
-    }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -11,8 +11,8 @@ import io.ejangs.docsa.domain.doc.dto.graph.GraphEdgeDto;
 import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleOnlyResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -42,13 +42,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DocService {
 
-    private final DocRepository docRepository;
     private final BranchRepository branchRepository;
     private final CommitRepository commitRepository;
     private final EdgeRepository edgeRepository;
 
     private final DocQueryService docQueryService;
-    private final DocCreateSagaService docCreateSagaService;
+    private final DocCreateOrchestrator docCreateOrchestrator;
 
     private final DocListAssembler docListAssembler;
     private final MongoIdsCollector mongoIdsCollector;
@@ -58,26 +57,24 @@ public class DocService {
         User user = docQueryService.getUserOrThrow(userId);
         String title = request.title();
         docQueryService.checkTitleDuplicate(userId, title);
-        return docCreateSagaService.create(title, user);
+        return docCreateOrchestrator.create(title, user);
     }
 
     @Transactional(readOnly = true)
-    public Page<DocListSimpleResponse> getSimplePage(Long userId, Pageable pageable) {
-        Page<Doc> docs = docQueryService.getAllDocPageByUserId(userId, pageable);
+    public Page<DocSimplePageResponse> getSimplePage(Long userId, Pageable pageable) {
+        Page<Doc> docs = docQueryService.getDocPageByUserId(userId, pageable);
         return docListAssembler.assembleDocListSimple(docs);
     }
 
     @Transactional(readOnly = true)
-    public Page<DocListResponse> getList(Long userId, Pageable pageable) {
-        Page<Doc> docs = docRepository.findAllByUserId(userId, pageable);
-
+    public Page<DocPageResponse> getPage(Long userId, Pageable pageable) {
+        Page<Doc> docs = docQueryService.getDocPageByUserId(userId, pageable);
         return docListAssembler.assembleDocList(docs);
     }
 
     @Transactional(readOnly = true)
-    public Page<DocListResponse> searchList(Long userId, String keyword, Pageable pageable) {
-        Page<Doc> docs = docRepository.searchDocByTitle(keyword, userId, pageable);
-
+    public Page<DocPageResponse> searchList(Long userId, String keyword, Pageable pageable) {
+        Page<Doc> docs = docQueryService.searchDoc(keyword,userId,pageable);
         return docListAssembler.assembleDocList(docs);
     }
 
@@ -85,7 +82,7 @@ public class DocService {
     public DocTitleUpdateResponse updateTitle(Long userId, Long docId, DocTitleRequest request) {
         String title = request.title();
 
-        Doc doc = getDocByIdAndUserId(docId, userId);
+        Doc doc = docQueryService.getByIdAndUserId(docId, userId);
 
         if (title.equals(doc.getTitle())) {
             throw new CustomException(DocErrorCode.SAME_AS_CURRENT_TITLE);
@@ -97,33 +94,11 @@ public class DocService {
         return DocMapper.toUpdateResponse(doc);
     }
 
-
-    public Doc getDocByIdAndUserId(Long documentId, Long userId) {
-        return docRepository.getDocByIdAndUserId(documentId, userId)
-                .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
-    }
-
-    public void checkDocByIdAndUserId(Long docId, Long userId) {
-        if (!docRepository.existsByIdAndUserId(docId, userId)) {
-            throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
-        }
-    }
-
-    //getDocByIdAndUserId로 대체할수 있지 않을까
-    @Transactional(readOnly = true)
-    public Doc getById(Long id) {
-        return docRepository.findById(id)
-                .orElseThrow(() -> new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND));
-    }
-
     // 문서 조회시 그래프를 그리기 위한 응답 생성
     @Transactional(readOnly = true)
     public CommitGraphResponse getGraph(Long userId, Long documentId) {
 
-        checkDocByIdAndUserId(documentId, userId);
-
-        // 문서 제목 조회
-        String docTitle = getTitleOnlyById(documentId);
+        String docTitle = docQueryService.getByIdAndUserId(documentId, userId).getTitle();
 
         //  Branch, Commit, Edge 각각 별도 조회 (Projection 쿼리)
         List<GraphBranchDto> branches = branchRepository.findBranchesByDocId(documentId);
@@ -136,22 +111,11 @@ public class DocService {
         return GraphMapper.toCommitGraphResponse(docTitle, commits, edges, branches);
     }
 
-    // 끔찍한 메소드
-    private String getTitleOnlyById(Long documentId) {
-        Optional<DocTitleOnlyResponse> optionalTitle = docRepository.findTitleOnlyById(documentId);
-
-        if (optionalTitle.isEmpty()) {
-            log.error("문서 ID {}의 제목 찾지 못함 (DocErrorCode.DOCUMENT_NOT_FOUND)", documentId);
-            throw new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND);
-        }
-
-        return optionalTitle.get().title();
-    }
 
     @Transactional
     public void delete(Long docId, Long userId) {
         User user = docQueryService.getUserOrThrow(userId);
-        Doc doc = getDocByIdAndUserId(docId, userId);
+        Doc doc = docQueryService.getByIdAndUserId(docId, userId);
         List<Edge> edges = doc.getEdges();
         List<Branch> branches = doc.getBranches();
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -3,7 +3,6 @@ package io.ejangs.docsa.domain.doc.app;
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
-import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dao.mysql.EdgeRepository;
 import io.ejangs.docsa.domain.doc.dto.graph.GraphBranchDto;
 import io.ejangs.docsa.domain.doc.dto.graph.GraphCommitDto;
@@ -13,7 +12,6 @@ import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocTitleOnlyResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
@@ -27,7 +25,6 @@ import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.mongo.deletion.dto.MongoIdsDto;
 import io.ejangs.docsa.global.mongo.deletion.util.MongoIdsCollector;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -62,19 +59,19 @@ public class DocService {
 
     @Transactional(readOnly = true)
     public Page<DocSimplePageResponse> getSimplePage(Long userId, Pageable pageable) {
-        Page<Doc> docs = docQueryService.getDocPageByUserId(userId, pageable);
+        Page<Doc> docs = docQueryService.getPageByUserId(userId, pageable);
         return docListAssembler.assembleDocListSimple(docs);
     }
 
     @Transactional(readOnly = true)
     public Page<DocPageResponse> getPage(Long userId, Pageable pageable) {
-        Page<Doc> docs = docQueryService.getDocPageByUserId(userId, pageable);
+        Page<Doc> docs = docQueryService.getPageByUserId(userId, pageable);
         return docListAssembler.assembleDocList(docs);
     }
 
     @Transactional(readOnly = true)
     public Page<DocPageResponse> searchList(Long userId, String keyword, Pageable pageable) {
-        Page<Doc> docs = docQueryService.searchDoc(keyword,userId,pageable);
+        Page<Doc> docs = docQueryService.searchByTitle(keyword,userId,pageable);
         return docListAssembler.assembleDocList(docs);
     }
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -63,9 +62,8 @@ public class DocService {
     }
 
     @Transactional(readOnly = true)
-    public Page<DocListSimpleResponse> getSimpleList(Long userId, Pageable pageable) {
-        Page<Doc> docs = docRepository.findAllByUserId(userId, pageable);
-
+    public Page<DocListSimpleResponse> getSimplePage(Long userId, Pageable pageable) {
+        Page<Doc> docs = docQueryService.getAllDocPageByUserId(userId, pageable);
         return docListAssembler.assembleDocListSimple(docs);
     }
 
@@ -111,6 +109,7 @@ public class DocService {
         }
     }
 
+    //getDocByIdAndUserId로 대체할수 있지 않을까
     @Transactional(readOnly = true)
     public Doc getById(Long id) {
         return docRepository.findById(id)
@@ -137,6 +136,7 @@ public class DocService {
         return GraphMapper.toCommitGraphResponse(docTitle, commits, edges, branches);
     }
 
+    // 끔찍한 메소드
     private String getTitleOnlyById(Long documentId) {
         Optional<DocTitleOnlyResponse> optionalTitle = docRepository.findTitleOnlyById(documentId);
 

--- a/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/app/DocService.java
@@ -56,8 +56,10 @@ public class DocService {
     private final ApplicationEventPublisher eventPublisher;
 
     public DocCreateResponse create(DocTitleRequest request, Long userId) {
-
-        return docCreateSagaService.create(request, userId);
+        User user = docQueryService.getUserOrThrow(userId);
+        String title = request.title();
+        docQueryService.checkTitleDuplicate(userId, title);
+        return docCreateSagaService.create(title, user);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dao/mysql/DocRepository.java
@@ -11,14 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface DocRepository extends JpaRepository<Doc, Long> {
 
-    @Query("""
-                SELECT new io.ejangs.docsa.domain.doc.dto.response.DocTitleOnlyResponse(d.title)
-                FROM Doc d
-                WHERE d.id = :docId
-            """)
-    Optional<DocTitleOnlyResponse> findTitleOnlyById(@Param("docId") Long docId);
-
-
     Optional<Doc> getDocByIdAndUserId(Long id, Long userId);
 
     boolean existsByUserIdAndTitle(Long userId, String title);

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/response/DocPageResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/response/DocPageResponse.java
@@ -3,20 +3,22 @@ package io.ejangs.docsa.domain.doc.dto.response;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto;
 import java.time.LocalDateTime;
 
-public record DocListSimpleResponse(
+public record DocPageResponse(
         Long id,
         String title,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
+        String preview,
         RecentActivityDto recent
 ) {
 
-    public DocListSimpleResponse(Long id, String title, LocalDateTime createdAt,
-            LocalDateTime updatedAt, RecentActivityDto recent) {
+    public DocPageResponse(Long id, String title, LocalDateTime createdAt,
+            LocalDateTime updatedAt, String preview, RecentActivityDto recent) {
         this.id = id;
         this.title = title;
         this.createdAt = createdAt.plusHours(9L);
         this.updatedAt = updatedAt.plusHours(9L);
+        this.preview = preview;
         this.recent = recent;
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/response/DocSimplePageResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/response/DocSimplePageResponse.java
@@ -3,22 +3,20 @@ package io.ejangs.docsa.domain.doc.dto.response;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto;
 import java.time.LocalDateTime;
 
-public record DocListResponse(
+public record DocSimplePageResponse(
         Long id,
         String title,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        String preview,
         RecentActivityDto recent
 ) {
 
-    public DocListResponse(Long id, String title, LocalDateTime createdAt,
-            LocalDateTime updatedAt, String preview, RecentActivityDto recent) {
+    public DocSimplePageResponse(Long id, String title, LocalDateTime createdAt,
+            LocalDateTime updatedAt, RecentActivityDto recent) {
         this.id = id;
         this.title = title;
         this.createdAt = createdAt.plusHours(9L);
         this.updatedAt = updatedAt.plusHours(9L);
-        this.preview = preview;
         this.recent = recent;
     }
 }

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListResponse.java
@@ -1,5 +1,5 @@
 package io.ejangs.docsa.domain.doc.dto.swagger;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -7,7 +7,7 @@ import java.util.List;
 public class PageDocListResponse {
 
     @Schema(description = "문서 목록")
-    private List<DocListResponse> content;
+    private List<DocPageResponse> content;
 
     @Schema(description = "페이지 정보")
     private PageableSchema pageable;

--- a/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListSimpleResponse.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/dto/swagger/PageDocListSimpleResponse.java
@@ -1,6 +1,6 @@
 package io.ejangs.docsa.domain.doc.dto.swagger;
 
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -8,7 +8,7 @@ import java.util.List;
 public class PageDocListSimpleResponse {
 
     @Schema(description = "문서 목록")
-    private List<DocListSimpleResponse> content;
+    private List<DocSimplePageResponse> content;
 
     @Schema(description = "페이지 정보")
     private PageableSchema pageable;

--- a/src/main/java/io/ejangs/docsa/domain/doc/util/DocListAssembler.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/util/DocListAssembler.java
@@ -4,8 +4,8 @@ import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.app.CommitContentAssembler;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
 import io.ejangs.docsa.domain.save.document.SaveContent;
@@ -28,7 +28,7 @@ public class DocListAssembler {
 
     private static final String DEFAULT_PREVIEW = "미리보기 없음";
 
-    public Page<DocListResponse> assembleDocList(Page<Doc> docs) {
+    public Page<DocPageResponse> assembleDocList(Page<Doc> docs) {
         return docs
                 .map(doc -> {
                     Branch recentBranch = getMostRecentBranch(doc);
@@ -38,7 +38,7 @@ public class DocListAssembler {
                 });
     }
 
-    public Page<DocListSimpleResponse> assembleDocListSimple(Page<Doc> docs) {
+    public Page<DocSimplePageResponse> assembleDocListSimple(Page<Doc> docs) {
         return docs
                 .map(doc -> {
                     Branch recentBranch = getMostRecentBranch(doc);

--- a/src/main/java/io/ejangs/docsa/domain/doc/util/DocMapper.java
+++ b/src/main/java/io/ejangs/docsa/domain/doc/util/DocMapper.java
@@ -2,8 +2,8 @@ package io.ejangs.docsa.domain.doc.util;
 
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.save.entity.Save;
@@ -22,8 +22,8 @@ public class DocMapper {
         );
     }
 
-    public static DocListSimpleResponse toListSimpleResponse(Doc doc, RecentActivityDto recent) {
-        return new DocListSimpleResponse(
+    public static DocSimplePageResponse toListSimpleResponse(Doc doc, RecentActivityDto recent) {
+        return new DocSimplePageResponse(
                 doc.getId(),
                 doc.getTitle(),
                 doc.getCreatedAt(),
@@ -32,9 +32,9 @@ public class DocMapper {
         );
     }
 
-    public static DocListResponse toListResponse(Doc doc, String preview,
+    public static DocPageResponse toListResponse(Doc doc, String preview,
             RecentActivityDto recent) {
-        return new DocListResponse(
+        return new DocPageResponse(
                 doc.getId(),
                 doc.getTitle(),
                 doc.getCreatedAt(),

--- a/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
+++ b/src/main/java/io/ejangs/docsa/domain/save/entity/Save.java
@@ -33,9 +33,10 @@ public class Save extends BaseEntity {
     private Branch branch;
 
     @Builder
-    private Save(Branch branch) {
+    private Save(Branch branch, String saveMongoId) {
         this.branch = branch;
         branch.setSave(this);
+        this.saveMongoId = saveMongoId;
     }
 
     public void updateSaveMongoId(String saveMongoId) {

--- a/src/main/java/io/ejangs/docsa/global/config/CorsProps.java
+++ b/src/main/java/io/ejangs/docsa/global/config/CorsProps.java
@@ -1,0 +1,16 @@
+package io.ejangs.docsa.global.config;// package io.ejangs.docsa.global.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProps {
+    private List<String> allowedOrigin = new ArrayList<>();
+
+}

--- a/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
+++ b/src/main/java/io/ejangs/docsa/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import io.ejangs.docsa.domain.user.security.CustomAuthenticationEntryPoint;
 import io.ejangs.docsa.domain.user.security.CustomUserDetailsService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     private final CustomUserDetailsService customUserDetailsService;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CorsProps corsProps;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
@@ -97,13 +99,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(
-                List.of(
-                        "http://localhost:3000",
-                        "http://localhost:5173",
-                        "https://docsa-4hh.pages.dev/",
-                        "https://docsa.o-r.kr/"
-                ));
+        configuration.setAllowedOrigins(corsProps.getAllowedOrigin());
         configuration.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
         );

--- a/src/main/java/io/ejangs/docsa/global/mongo/deletion/app/MongoDeleteFailureScheduler.java
+++ b/src/main/java/io/ejangs/docsa/global/mongo/deletion/app/MongoDeleteFailureScheduler.java
@@ -17,7 +17,9 @@ public class MongoDeleteFailureScheduler {
 
     private final MongoDeleteFailureRepository mongoDeleteFailureRepository;
     private final MongoDeleteRetryService mongoDeleteRetryService;
-
+    //TODO
+    // 스케줄러 재시도 실패 시 동일 MongoIdsDto가 중복 저장되는 문제 개선 (중복 방지 키 또는 상태 업데이트 방식으로 전환)
+	// 스케줄러의 트랜잭션 매니저 분리 (RDB는 JPA, Mongo는 mongoTransactionManager로 역할 명확화)
     @Scheduled(fixedDelay = 1000 * 60 * 60 * 24 * 7)
     @Transactional(transactionManager = "mongoTransactionManager")
     public void run() {

--- a/src/main/java/io/ejangs/docsa/global/mongo/deletion/app/MongoDeleteRetryService.java
+++ b/src/main/java/io/ejangs/docsa/global/mongo/deletion/app/MongoDeleteRetryService.java
@@ -37,19 +37,9 @@ public class MongoDeleteRetryService {
                 ? RetrySynchronizationManager.getContext().getRetryCount()
                 : 0;
         log.warn("[MONGO] MongoDeleteRetryService 에서 호출, MongoDelete Retry count = {}", retryCount);
-
-        for (String saveContentId : dto.saveContentsIds()) {
-            saveContentRepository.deleteById(saveContentId);
-            log.warn("[MONGO] MongoDeleteRetryService 에서 호출, MongoDelete Save Content id = {}", saveContentId);
-        }
-        for (String commitBlockSequenceId : dto.commitBlockSequenceIds()) {
-            commitBlockSequenceRepository.deleteById(commitBlockSequenceId);
-            log.warn("[MONGO] MongoDeleteRetryService 에서 호출, MongoDelete Commit Block Sequence id = {}", commitBlockSequenceId);
-        }
-        for (String blockId : dto.blockIds()) {
-            blockRepository.deleteById(blockId);
-            log.warn("[MONGO] MongoDeleteRetryService 에서 호출, MongoDelete Block id = {}", blockId);
-        }
+        saveContentRepository.deleteAllById(dto.saveContentsIds());
+        commitBlockSequenceRepository.deleteAllById(dto.commitBlockSequenceIds());
+        blockRepository.deleteAllById(dto.blockIds());
     }
 
     @Recover

--- a/src/main/java/io/ejangs/docsa/global/mongo/deletion/dto/MongoIdsDto.java
+++ b/src/main/java/io/ejangs/docsa/global/mongo/deletion/dto/MongoIdsDto.java
@@ -16,4 +16,12 @@ public record MongoIdsDto(
         blockIds = blockIds == null ? List.of() : blockIds;
     }
 
+    public static MongoIdsDto forSaveContent(String saveContentId) {
+        return new MongoIdsDto(
+                List.of(saveContentId),
+                List.of(),
+                List.of()
+        );
+    }
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,6 +27,12 @@ spring:
 server:
   port: 8080
 
+app:
+  cors:
+    allowed-origin:
+      - "http://localhost:3000"
+      - "http://localhost:5173"
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,12 @@ server:
         same-site: None
       timeout: 24h # TODO: 테스트 완료 후 제거
 
+app:
+  cors:
+    allowed-origin:
+      - "https://docsa.o-r.kr",
+      - "https://docsa-4hh.pages.dev"
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/main/resources/application-stg.yml
+++ b/src/main/resources/application-stg.yml
@@ -39,6 +39,12 @@ server:
         same-site: None
       timeout: 24h # TODO: 테스트 완료 후 제거
 
+app:
+  cors:
+    allowed-origin:
+      - "https://stg.docsa.o-r.kr"
+      - "https://staging.docsa-4hh.pages.dev"
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/CommitServiceMockTest.java
@@ -24,6 +24,7 @@ import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.commit.util.CommitBlockSequenceMapper;
 import io.ejangs.docsa.domain.commit.util.CommitMapper;
 import io.ejangs.docsa.domain.commit.util.CommitMockTestUtils;
+import io.ejangs.docsa.domain.doc.app.DocQueryService;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.app.EdgeService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -57,7 +58,7 @@ class CommitServiceMockTest {
     private CommitBlockSequenceRepository cbsRepository;
 
     @Mock
-    private DocService docService;
+    private DocQueryService docQueryService;
 
     @Mock
     private BranchService branchService;
@@ -149,7 +150,7 @@ class CommitServiceMockTest {
     @DisplayName("커밋 생성 성공 - 기본")
     void createCommit_Success() {
         // Given
-        when(docService.getById(docId)).thenReturn(doc);
+        when(docQueryService.getById(docId)).thenReturn(doc);
         when(branchService.getById(branchId)).thenReturn(branch);
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         lenient().when(cbsRepository.findById(baseCommit.getCommitMongoId())).thenReturn(
@@ -173,7 +174,7 @@ class CommitServiceMockTest {
             // Then
             assertThat(result).isEqualTo(expectedResponse);
 
-            verify(docService).getById(docId);
+            verify(docQueryService).getById(docId);
             verify(branchService).getById(branchId);
             verify(blockService).saveBlocks(createCommitRequest.blocks());
             verify(cbsRepository).save(savedCbs);
@@ -185,7 +186,7 @@ class CommitServiceMockTest {
     @DisplayName("커밋 생성 성공 - 기존 Save 삭제")
     void createCommit_Success_DeleteExistingSave() {
         // Given
-        when(docService.getById(docId)).thenReturn(doc);
+        when(docQueryService.getById(docId)).thenReturn(doc);
         when(branchService.getById(branchId)).thenReturn(branch);
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         lenient().when(cbsRepository.findById(baseCommit.getCommitMongoId())).thenReturn(
@@ -219,7 +220,7 @@ class CommitServiceMockTest {
         Branch branchWithoutLeafCommit = CommitMockTestUtils.createBranch(doc, baseCommit);
         branchWithoutLeafCommit.updateLeafCommit(null); // leafCommit을 null로 설정
 
-        when(docService.getById(docId)).thenReturn(doc);
+        when(docQueryService.getById(docId)).thenReturn(doc);
         when(branchService.getById(branchId)).thenReturn(branchWithoutLeafCommit);
         when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
         when(cbsRepository.findById(
@@ -253,14 +254,14 @@ class CommitServiceMockTest {
     void createCommit_Fail_DocNotFound() {
         // Given
         doThrow(new CustomException(BlockSequenceErrorCode.BLOCK_SEQUENCE_NOT_FOUND))
-                .when(docService).getById(docId);
+                .when(docQueryService).getById(docId);
 
         // When & Then
         assertThatThrownBy(() -> commitService.createCommit(docId, createCommitRequest,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).getById(docId);
+        verify(docQueryService).getById(docId);
         verify(branchService, never()).getById(any());
         verify(blockService, never()).saveBlocks(any());
     }
@@ -269,7 +270,7 @@ class CommitServiceMockTest {
     @DisplayName("커밋 생성 실패 - 블록 저장 실패시")
     void createCommit_Fail_BlockSaveFails_ShouldRollback() {
         // Given
-        when(docService.getById(docId)).thenReturn(doc);
+        when(docQueryService.getById(docId)).thenReturn(doc);
         when(branchService.getById(branchId)).thenReturn(branch);
         when(blockService.saveBlocks(any())).thenThrow(new RuntimeException("Block save failed"));
 
@@ -287,7 +288,7 @@ class CommitServiceMockTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage(DatabaseErrorCode.DATABASE_ERROR.getMessage());
 
-            verify(docService).getById(docId);
+            verify(docQueryService).getById(docId);
             verify(branchService).getById(branchId);
             verify(blockService).saveBlocks(createCommitRequest.blocks());
             verify(cbsRepository, never()).save(any());
@@ -298,7 +299,7 @@ class CommitServiceMockTest {
     @DisplayName("커밋 생성 실패 - JPA 저장 실패시 MongoDB 호출 안함")
     void createCommit_Fail_JpaSaveFails_ShouldRollbackMongoDB() {
         // Given
-        when(docService.getById(docId)).thenReturn(doc);
+        when(docQueryService.getById(docId)).thenReturn(doc);
         lenient().when(branchService.getById(branchId)).thenReturn(branch);
         lenient().when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
 
@@ -338,7 +339,7 @@ class CommitServiceMockTest {
                 CommitBlockSequenceMapper.class);
                 MockedStatic<CommitMapper> commitMapperMock = mockStatic(CommitMapper.class)) {
 
-            when(docService.getById(docId)).thenReturn(doc);
+            when(docQueryService.getById(docId)).thenReturn(doc);
             when(branchService.getById(branchId)).thenReturn(branch);
             when(blockService.saveBlocks(any())).thenReturn(savedBlocks);
             when(CommitMapper.toEntity(branch, invalidRequest)).thenReturn(

--- a/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/commit/app/GetCommitMockTest.java
@@ -15,7 +15,7 @@ import io.ejangs.docsa.domain.commit.dto.response.CommitResponse;
 import io.ejangs.docsa.domain.commit.dto.response.CompareMergeCommitResponse;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.commit.util.CommitMockTestUtils;
-import io.ejangs.docsa.domain.doc.app.DocService;
+import io.ejangs.docsa.domain.doc.app.DocQueryService;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.domain.user.security.CustomUserDetails;
@@ -42,7 +42,7 @@ class GetCommitMockTest {
     private BranchService branchService;
 
     @Mock
-    private DocService docService;
+    private DocQueryService docQueryService;
 
     @Mock
     private CommitContentAssembler assembler;
@@ -96,7 +96,7 @@ class GetCommitMockTest {
         assertThat(response).isNotNull();
         assertThat(response.content()).isEqualTo(mockContent);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler).assemble(commitMongoId);
     }
@@ -114,7 +114,7 @@ class GetCommitMockTest {
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(commitId);
         verify(assembler, never()).assemble(any());
     }
@@ -127,13 +127,13 @@ class GetCommitMockTest {
         Long commitId = 1L;
 
         doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
-                .when(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+                .when(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
 
         // when & then
         assertThatThrownBy(() -> commitService.getCommit(docId, commitId, userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }
@@ -165,7 +165,7 @@ class GetCommitMockTest {
         assertThat(response.base()).isEqualTo(baseContent);
         assertThat(response.target()).isEqualTo(targetContent);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -187,7 +187,7 @@ class GetCommitMockTest {
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository, never()).findById(targetId);
         verify(assembler, never()).assemble(any());
@@ -213,7 +213,7 @@ class GetCommitMockTest {
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository).findById(baseId);
         verify(commitRepository).findById(targetId);
         verify(assembler).assemble(baseCommitMongoId);
@@ -228,14 +228,14 @@ class GetCommitMockTest {
         Long targetId = 2L;
 
         doThrow(new CustomException(DocErrorCode.DOCUMENT_NOT_FOUND))
-                .when(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+                .when(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
 
         // when & then
         assertThatThrownBy(() -> commitService.compareCommitForMerge(docId, baseId, targetId,
                 userDetails.getId()))
                 .isInstanceOf(CustomException.class);
 
-        verify(docService).checkDocByIdAndUserId(docId, userDetails.getId());
+        verify(docQueryService).checkByIdAndUserId(docId, userDetails.getId());
         verify(commitRepository, never()).findById(any());
         verify(assembler, never()).assemble(any());
     }

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocGraphIntegrationTest.java
@@ -2,6 +2,7 @@ package io.ejangs.docsa.domain.doc.integration;
 
 import io.ejangs.docsa.domain.block.dao.mongodb.BlockRepository;
 import io.ejangs.docsa.domain.commit.dao.mongodb.CommitBlockSequenceRepository;
+import io.ejangs.docsa.domain.doc.app.DocQueryService;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -43,7 +44,7 @@ public class DocGraphIntegrationTest {
     private BlockRepository blockRepository;
 
     @InjectMocks
-    private DocService docService;
+    private DocQueryService docQueryService;
 
     private User user;
 
@@ -65,7 +66,7 @@ public class DocGraphIntegrationTest {
 
         when(docRepository.findById(doc.getId())).thenReturn(Optional.of(doc));
 
-        Doc result = docService.getById(doc.getId());
+        Doc result = docQueryService.getById(doc.getId());
 
         assertThat(result).isNotNull();
         assertThat(result.getTitle()).isEqualTo("브랜치 2개 있는 문서임당");

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -20,8 +20,8 @@ import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto.RecentType;
 import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.util.DocTestUtils;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
@@ -251,14 +251,14 @@ public class DocServiceIntegrationTests {
         Pageable pageable = PageableFactory.create("updatedAt", "asc", 0, 10);
 
         // when
-        Page<DocListSimpleResponse> page = docService.getSimplePage(user.getId(), pageable);
-        List<DocListSimpleResponse> results = page.getContent();
+        Page<DocSimplePageResponse> page = docService.getSimplePage(user.getId(), pageable);
+        List<DocSimplePageResponse> results = page.getContent();
 
         // then
         assertEquals(2, results.size());
 
-        DocListSimpleResponse first = results.get(0);  // 최신 updatedAt 기준으로 정렬되었다고 가정
-        DocListSimpleResponse second = results.get(1);
+        DocSimplePageResponse first = results.get(0);  // 최신 updatedAt 기준으로 정렬되었다고 가정
+        DocSimplePageResponse second = results.get(1);
 
         // 저장이 없음 -> 최신 커밋
         assertEquals("문서 1", first.title());
@@ -282,13 +282,13 @@ public class DocServiceIntegrationTests {
         Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
 
         // when
-        Page<DocListResponse> results = docService.getList(user.getId(), pageable);
+        Page<DocPageResponse> results = docService.getPage(user.getId(), pageable);
 
         // then
         assertEquals(2, results.getContent().size());
 
-        DocListResponse first = results.getContent().getFirst();  // updatedAt 기준 최신
-        DocListResponse second = results.getContent().get(1);
+        DocPageResponse first = results.getContent().getFirst();  // updatedAt 기준 최신
+        DocPageResponse second = results.getContent().get(1);
 
         assertEquals("문서 1", second.title());
         assertEquals(RecentType.COMMIT, second.recent().recentType());
@@ -310,15 +310,15 @@ public class DocServiceIntegrationTests {
         Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
 
         //when
-        Page<DocListResponse> result = docService.getList(user.getId(), pageable);
+        Page<DocPageResponse> result = docService.getPage(user.getId(), pageable);
 
         //then
         assertEquals(10, result.getContent().size());
-        DocListResponse first = result.getContent().getFirst();
+        DocPageResponse first = result.getContent().getFirst();
         assertEquals("문서 keyword포함100", first.title());
         assertEquals(100L, first.id());
 
-        DocListResponse last = result.getContent().getLast();
+        DocPageResponse last = result.getContent().getLast();
         assertEquals("테스트 문서 91", last.title());
         assertEquals(91L, last.id());
     }
@@ -336,12 +336,12 @@ public class DocServiceIntegrationTests {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("updatedAt").descending());
 
         // when
-        Page<DocListResponse> result = docService.searchList(user.getId(), keyword, pageable);
+        Page<DocPageResponse> result = docService.searchList(user.getId(), keyword, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(10);
         assertThat(result.getContent())
-                .extracting(DocListResponse::title)
+                .extracting(DocPageResponse::title)
                 .allMatch(title -> title.contains("keyword"));
         assertThat(result.getContent().getFirst().id()).isEqualTo(300);
     }

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -252,7 +251,7 @@ public class DocServiceIntegrationTests {
         Pageable pageable = PageableFactory.create("updatedAt", "asc", 0, 10);
 
         // when
-        Page<DocListSimpleResponse> page = docService.getSimpleList(user.getId(), pageable);
+        Page<DocListSimpleResponse> page = docService.getSimplePage(user.getId(), pageable);
         List<DocListSimpleResponse> results = page.getContent();
 
         // then

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.MongoTimeoutException;
@@ -13,6 +15,7 @@ import io.ejangs.docsa.domain.block.dao.mongodb.BlockRepository;
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.branch.entity.Branch;
 import io.ejangs.docsa.domain.commit.dao.mongodb.CommitBlockSequenceRepository;
+import io.ejangs.docsa.domain.doc.app.DocCreateMySqlTxService;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto.RecentType;
@@ -151,7 +154,7 @@ public class DocServiceIntegrationTests {
         private SaveContentRepository saveContentRepository;
 
         @Test
-        @DisplayName("Mongo 저장 실패 시 문서 생성 트랜잭션이 중단된다")
+        @DisplayName("Mongo 저장 실패 시 예외")
         @Transactional(propagation = Propagation.NOT_SUPPORTED)
             // findAll이 같은 트랜잭션 안에서 수행 되면 rollback 되기 전 상태를 그대로 읽을 수 있음
         void MongoFailRdbTransaction() {
@@ -164,12 +167,48 @@ public class DocServiceIntegrationTests {
             assertThatThrownBy(() -> docService.create(request, user.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(DatabaseErrorCode.DATABASE_ERROR.getMessage());
-
-            assertThat(docRepository.findAll()).isEmpty();
-            assertThat(branchRepository.findAll()).isEmpty();
-            assertThat(saveRepository.findAll()).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("MySQL 실패시 MongoDB 보상 삭제")
+    class MySqlFailureTest {
+
+        @Autowired
+        private DocService docService;
+
+        @Autowired
+        private UserRepository userRepository;
+
+        @Autowired
+        private SaveContentRepository saveContentRepository;
+
+        @MockitoBean
+        private DocCreateMySqlTxService docCreateMySqlTxService; // MySQL 파트만 실패 유도
+
+        @Test
+        @DisplayName("MySQL 생성 실패 시 Mongo에 먼저 생성된 SaveContent는 보상 삭제된다")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        void mysqlFail_compensateMongoDelete() {
+            // given
+            User user = userRepository.save(DocTestUtils.createUser());
+            DocTitleRequest request = new DocTitleRequest("MySQL 실패 케이스");
+
+            // Mongo는 정상 저장되고, MySQL 파트에서 예외가 터진 상황
+            when(docCreateMySqlTxService.createMySqlPart(any(), any(), anyString()))
+                    .thenThrow(new RuntimeException("MySQL 생성 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> docService.create(request, user.getId()))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("MySQL 생성 실패");
+
+            // 보상 삭제 결과: Mongo에 SaveContent가 남아있으면 안 됨
+            assertThat(saveContentRepository.findAll()).isEmpty();
+        }
+    }
+
+
 
     @Test
     @DisplayName("중복된 제목으로 문서를 생성할 경우 예외가 발생한다")

--- a/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/integration/DocServiceIntegrationTests.java
@@ -2,11 +2,13 @@ package io.ejangs.docsa.domain.doc.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.MongoTimeoutException;
@@ -35,6 +37,9 @@ import io.ejangs.docsa.global.exception.CustomException;
 import io.ejangs.docsa.global.exception.errorcode.DatabaseErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import io.ejangs.docsa.global.exception.errorcode.UserErrorCode;
+import io.ejangs.docsa.global.mongo.deletion.app.MongoDeleteRetryService;
+import io.ejangs.docsa.global.mongo.deletion.dao.mysql.MongoDeleteFailureRepository;
+import io.ejangs.docsa.global.mongo.deletion.entity.MongoDeleteFailure;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +56,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,13 +91,22 @@ public class DocServiceIntegrationTests {
     @Autowired
     private BlockRepository blockRepository;
 
+    @Autowired
+    private MongoDeleteFailureRepository mongoDeleteFailureRepository;
+
     @Value("${default.branch}")
     private String defaultBranchName;
 
     @AfterEach
     void cleanup() {
+        userRepository.deleteAll();
         docRepository.deleteAll();
+        branchRepository.deleteAll();
+        saveRepository.deleteAll();
+        commitBlockSequenceRepository.deleteAll();
+        blockRepository.deleteAll();
         saveContentRepository.deleteAll();
+        mongoDeleteFailureRepository.deleteAll();
     }
 
     @Test
@@ -206,7 +221,56 @@ public class DocServiceIntegrationTests {
             assertThat(saveContentRepository.findAll()).isEmpty();
         }
     }
+    @Nested
+    @DisplayName("MySQL 실패 + 보상 삭제 3회 실패")
+    class MySqlFailureWithCompensateFailureTest {
 
+        @Autowired
+        private DocService docService;
+
+        @Autowired
+        private UserRepository userRepository;
+
+        @Autowired
+        private MongoDeleteFailureRepository mongoDeleteFailureRepository;
+
+        @MockitoBean
+        private DocCreateMySqlTxService docCreateMySqlTxService;
+
+        @MockitoSpyBean
+        private MongoDeleteRetryService mongoDeleteRetryService;
+
+        @Test
+        @DisplayName("보상 삭제가 3회 모두 실패하면 MongoDeleteFailure가 저장된다")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        void mysqlFail_and_compensateFail_storeFailure() {
+
+            // given
+            User user = userRepository.save(DocTestUtils.createUser());
+            DocTitleRequest request = new DocTitleRequest("보상 실패 케이스");
+
+            // MySQL 파트 실패
+            when(docCreateMySqlTxService.createMySqlPart(any(), any(), anyString()))
+                    .thenThrow(new RuntimeException("MySQL 생성 실패"));
+
+            // 보상 삭제도 실패
+            doThrow(new RuntimeException("보상 삭제 실패"))
+                    .when(mongoDeleteRetryService).deleteMongoData(any());
+
+            // when
+            assertThatThrownBy(() -> docService.create(request, user.getId()))
+                    .isInstanceOf(RuntimeException.class);
+
+            // then (비동기 or recover 고려)
+            await().untilAsserted(() -> {
+                List<MongoDeleteFailure> failures =
+                        mongoDeleteFailureRepository.findAll();
+
+                assertThat(failures).hasSize(1);
+                assertThat(failures.get(0).getResolved()).isFalse();
+            });
+        }
+    }
 
 
     @Test

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
@@ -19,7 +19,7 @@ import io.ejangs.docsa.domain.doc.dto.RecentActivityDto.RecentType;
 import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocCreateResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.global.exception.CustomException;
@@ -95,15 +95,15 @@ class DocControllerUnitTests {
     @DisplayName("문서 리스트 조회 컨트롤러 테스트 - 사이드바")
     void getSimpleDocList() throws Exception {
         // given
-        List<DocListSimpleResponse> content = List.of(
-                new DocListSimpleResponse(
+        List<DocSimplePageResponse> content = List.of(
+                new DocSimplePageResponse(
                         1L,
                         "마이크로소프트",
                         LocalDateTime.of(2025, 7, 6, 12, 0),
                         LocalDateTime.of(2025, 7, 7, 9, 0),
                         new RecentActivityDto(RecentType.SAVE, 10L)
                 ),
-                new DocListSimpleResponse(
+                new DocSimplePageResponse(
                         2L,
                         "구글",
                         LocalDateTime.of(2025, 6, 28, 15, 30),
@@ -114,7 +114,7 @@ class DocControllerUnitTests {
 
         Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
 
-        Page<DocListSimpleResponse> responseList = new PageImpl<>(
+        Page<DocSimplePageResponse> responseList = new PageImpl<>(
                 content,
                 PageRequest.of(0, 10),
                 content.size()

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocControllerUnitTests.java
@@ -120,7 +120,7 @@ class DocControllerUnitTests {
                 content.size()
         );
 
-        when(docService.getSimpleList(anyLong(), any(Pageable.class))).thenReturn(responseList);
+        when(docService.getSimplePage(anyLong(), any(Pageable.class))).thenReturn(responseList);
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders.get("/api/document/sidebar"))

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -100,7 +100,7 @@ public class DocServiceUnitTests {
         Page<DocSimplePageResponse> dummyPage = new PageImpl<>(expectedResponses, pageable,
                 expectedResponses.size());
 
-        when(docQueryService.getDocPageByUserId(userId, pageable)).thenReturn(docs);
+        when(docQueryService.getPageByUserId(userId, pageable)).thenReturn(docs);
         when(docListAssembler.assembleDocListSimple(docs)).thenReturn(dummyPage);
 
         // when
@@ -118,7 +118,7 @@ public class DocServiceUnitTests {
         assertEquals(RecentType.COMMIT, result.get(1).recent().recentType());
         assertEquals(200L, result.get(1).recent().recentTypeId());
 
-        verify(docQueryService).getDocPageByUserId(userId, pageable);
+        verify(docQueryService).getPageByUserId(userId, pageable);
         verify(docListAssembler).assembleDocListSimple(docs);
     }
 
@@ -149,7 +149,7 @@ public class DocServiceUnitTests {
         Page<DocPageResponse> responsesPage = DocTestUtils.convertToDocListResponsePage(pagedDocs,
                 pageable);
 
-        when(docRepository.searchDocByTitle(keyword, userId, pageable)).thenReturn(docsPage);
+        when(docQueryService.searchByTitle(keyword, userId, pageable)).thenReturn(docsPage);
         when(docListAssembler.assembleDocList(docsPage)).thenReturn(responsesPage);
 
         // when
@@ -162,7 +162,7 @@ public class DocServiceUnitTests {
         assertEquals("테스트 문서 19", result.get(1).title());
         assertEquals("테스트 문서 11", result.getLast().title());
 
-        verify(docRepository).searchDocByTitle(keyword, userId, pageable);
+        verify(docQueryService).searchByTitle(keyword, userId, pageable);
         verify(docListAssembler).assembleDocList(docsPage);
     }
 
@@ -187,14 +187,14 @@ public class DocServiceUnitTests {
         DocTitleUpdateResponse response =
                 new DocTitleUpdateResponse(docId, newTitle, LocalDateTime.now());
 
-        when(docRepository.getDocByIdAndUserId(docId, userId)).thenReturn(Optional.of(doc));
+        when(docQueryService.getByIdAndUserId(docId, userId)).thenReturn(doc);
 
         //when
         DocTitleUpdateResponse result = docService.updateTitle(userId, docId, request);
 
         //then
         verify(docQueryService).checkTitleDuplicate(userId, newTitle);
-        verify(docRepository).getDocByIdAndUserId(docId, userId);
+        verify(docQueryService).getByIdAndUserId(docId, userId);
         assertEquals(newTitle, doc.getTitle());
         assertEquals(response.id(), doc.getId());
         assertEquals(response.title(), result.title());
@@ -215,7 +215,7 @@ public class DocServiceUnitTests {
         Doc doc = Doc.builder().title("기존 제목").user(user).build();
         ReflectionTestUtils.setField(doc, "id", docId);
 
-        when(docRepository.getDocByIdAndUserId(docId, userId)).thenReturn(Optional.of(doc));
+        when(docQueryService.getByIdAndUserId(docId, userId)).thenReturn(doc);
         doThrow(new CustomException(DocErrorCode.TITLE_DUPLICATION))
                 .when(docQueryService).checkTitleDuplicate(userId, duplicateTitle);
 
@@ -231,12 +231,17 @@ public class DocServiceUnitTests {
     void getGraph_shouldReturnGraphResponse_whenDocExists() {
         Long userId = 1L;
         Long docId = 10L;
+        String docTitle = "Test Document";
 
-        when(docRepository.existsByIdAndUserId(docId, userId)).thenReturn(true);
+        User user = DocTestUtils.createUser();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Doc doc = Doc.builder().title(docTitle).user(user).build();
+        ReflectionTestUtils.setField(doc, "id", docId);
 
         // Mock 문서 제목 조회
-        when(docRepository.findTitleOnlyById(docId))
-                .thenReturn(Optional.of(new DocTitleOnlyResponse("Test Document")));
+        when(docQueryService.getByIdAndUserId(docId, userId))
+                .thenReturn(doc);
 
         // Mock Branch, Commit, Edge 리스트
         LocalDateTime now = LocalDateTime.now();
@@ -256,7 +261,7 @@ public class DocServiceUnitTests {
 
         CommitGraphResponse response = docService.getGraph(userId, docId);
 
-        assertEquals("Test Document", response.title());
+        assertEquals(docTitle, response.title());
         assertEquals(branches, response.branches());
         assertEquals(commits, response.commits());
         assertEquals(edges, response.edges());

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -19,8 +19,8 @@ import io.ejangs.docsa.domain.doc.dto.graph.GraphCommitDto;
 import io.ejangs.docsa.domain.doc.dto.graph.GraphEdgeDto;
 import io.ejangs.docsa.domain.doc.dto.request.DocTitleRequest;
 import io.ejangs.docsa.domain.doc.dto.response.CommitGraphResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
-import io.ejangs.docsa.domain.doc.dto.response.DocListSimpleResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocSimplePageResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleOnlyResponse;
 import io.ejangs.docsa.domain.doc.dto.response.DocTitleUpdateResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
@@ -81,15 +81,15 @@ public class DocServiceUnitTests {
         Pageable pageable = PageableFactory.create("updatedAt", "desc", 0, 10);
         Page<Doc> docs = new PageImpl<>(content, pageable, content.size());
 
-        List<DocListSimpleResponse> expectedResponses = List.of(
-                new DocListSimpleResponse(
+        List<DocSimplePageResponse> expectedResponses = List.of(
+                new DocSimplePageResponse(
                         1L,
                         "테스트 문서 1",
                         LocalDateTime.of(2025, 7, 16, 2, 0),
                         LocalDateTime.of(2025, 7, 16, 2, 0),
                         new RecentActivityDto(RecentType.SAVE, 10L)
                 ),
-                new DocListSimpleResponse(
+                new DocSimplePageResponse(
                         2L,
                         "테스트 문서 2",
                         LocalDateTime.of(2025, 7, 16, 3, 0),
@@ -97,15 +97,15 @@ public class DocServiceUnitTests {
                         new RecentActivityDto(RecentType.COMMIT, 200L)
                 )
         );
-        Page<DocListSimpleResponse> dummyPage = new PageImpl<>(expectedResponses, pageable,
+        Page<DocSimplePageResponse> dummyPage = new PageImpl<>(expectedResponses, pageable,
                 expectedResponses.size());
 
-        when(docQueryService.getAllDocPageByUserId(userId, pageable)).thenReturn(docs);
+        when(docQueryService.getDocPageByUserId(userId, pageable)).thenReturn(docs);
         when(docListAssembler.assembleDocListSimple(docs)).thenReturn(dummyPage);
 
         // when
-        Page<DocListSimpleResponse> page = docService.getSimplePage(userId, pageable);
-        List<DocListSimpleResponse> result = page.getContent();
+        Page<DocSimplePageResponse> page = docService.getSimplePage(userId, pageable);
+        List<DocSimplePageResponse> result = page.getContent();
 
         // then
         assertEquals(2, result.size());
@@ -118,7 +118,7 @@ public class DocServiceUnitTests {
         assertEquals(RecentType.COMMIT, result.get(1).recent().recentType());
         assertEquals(200L, result.get(1).recent().recentTypeId());
 
-        verify(docQueryService).getAllDocPageByUserId(userId, pageable);
+        verify(docQueryService).getDocPageByUserId(userId, pageable);
         verify(docListAssembler).assembleDocListSimple(docs);
     }
 
@@ -146,15 +146,15 @@ public class DocServiceUnitTests {
         List<Doc> pagedDocs = filtered.subList(start, end);
 
         Page<Doc> docsPage = new PageImpl<>(pagedDocs, pageable, filtered.size());
-        Page<DocListResponse> responsesPage = DocTestUtils.convertToDocListResponsePage(pagedDocs,
+        Page<DocPageResponse> responsesPage = DocTestUtils.convertToDocListResponsePage(pagedDocs,
                 pageable);
 
         when(docRepository.searchDocByTitle(keyword, userId, pageable)).thenReturn(docsPage);
         when(docListAssembler.assembleDocList(docsPage)).thenReturn(responsesPage);
 
         // when
-        Page<DocListResponse> page = docService.searchList(userId, keyword, pageable);
-        List<DocListResponse> result = page.getContent();
+        Page<DocPageResponse> page = docService.searchList(userId, keyword, pageable);
+        List<DocPageResponse> result = page.getContent();
 
         // then
         assertEquals(10, result.size());

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -100,11 +100,11 @@ public class DocServiceUnitTests {
         Page<DocListSimpleResponse> dummyPage = new PageImpl<>(expectedResponses, pageable,
                 expectedResponses.size());
 
-        when(docRepository.findAllByUserId(userId, pageable)).thenReturn(docs);
+        when(docQueryService.getAllDocPageByUserId(userId, pageable)).thenReturn(docs);
         when(docListAssembler.assembleDocListSimple(docs)).thenReturn(dummyPage);
 
         // when
-        Page<DocListSimpleResponse> page = docService.getSimpleList(userId, pageable);
+        Page<DocListSimpleResponse> page = docService.getSimplePage(userId, pageable);
         List<DocListSimpleResponse> result = page.getContent();
 
         // then
@@ -118,7 +118,7 @@ public class DocServiceUnitTests {
         assertEquals(RecentType.COMMIT, result.get(1).recent().recentType());
         assertEquals(200L, result.get(1).recent().recentTypeId());
 
-        verify(docRepository).findAllByUserId(userId, pageable);
+        verify(docQueryService).getAllDocPageByUserId(userId, pageable);
         verify(docListAssembler).assembleDocListSimple(docs);
     }
 

--- a/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/unit/DocServiceUnitTests.java
@@ -2,11 +2,13 @@ package io.ejangs.docsa.domain.doc.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.ejangs.docsa.domain.branch.dao.mysql.BranchRepository;
 import io.ejangs.docsa.domain.commit.dao.mysql.CommitRepository;
+import io.ejangs.docsa.domain.doc.app.DocQueryService;
 import io.ejangs.docsa.domain.doc.app.DocService;
 import io.ejangs.docsa.domain.doc.dao.mysql.DocRepository;
 import io.ejangs.docsa.domain.doc.dao.mysql.EdgeRepository;
@@ -27,6 +29,7 @@ import io.ejangs.docsa.domain.doc.util.DocTestUtils;
 import io.ejangs.docsa.domain.save.util.PageableFactory;
 import io.ejangs.docsa.domain.user.entity.User;
 import io.ejangs.docsa.global.exception.CustomException;
+import io.ejangs.docsa.global.exception.errorcode.DocErrorCode;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -50,6 +53,9 @@ public class DocServiceUnitTests {
 
     @Mock
     private DocRepository docRepository;
+
+    @Mock
+    private DocQueryService docQueryService;
 
     @Mock
     private DocListAssembler docListAssembler;
@@ -181,14 +187,13 @@ public class DocServiceUnitTests {
         DocTitleUpdateResponse response =
                 new DocTitleUpdateResponse(docId, newTitle, LocalDateTime.now());
 
-        when(docRepository.existsByUserIdAndTitle(userId, newTitle)).thenReturn(false);
         when(docRepository.getDocByIdAndUserId(docId, userId)).thenReturn(Optional.of(doc));
 
         //when
         DocTitleUpdateResponse result = docService.updateTitle(userId, docId, request);
 
         //then
-        verify(docRepository).existsByUserIdAndTitle(userId, newTitle);
+        verify(docQueryService).checkTitleDuplicate(userId, newTitle);
         verify(docRepository).getDocByIdAndUserId(docId, userId);
         assertEquals(newTitle, doc.getTitle());
         assertEquals(response.id(), doc.getId());
@@ -211,10 +216,14 @@ public class DocServiceUnitTests {
         ReflectionTestUtils.setField(doc, "id", docId);
 
         when(docRepository.getDocByIdAndUserId(docId, userId)).thenReturn(Optional.of(doc));
-        when(docRepository.existsByUserIdAndTitle(userId, duplicateTitle)).thenReturn(true);
+        doThrow(new CustomException(DocErrorCode.TITLE_DUPLICATION))
+                .when(docQueryService).checkTitleDuplicate(userId, duplicateTitle);
 
         // when & then
-        assertThrows(CustomException.class, () -> docService.updateTitle(userId, docId, request));
+        CustomException exception = assertThrows(CustomException.class,
+                () -> docService.updateTitle(userId, docId, request));
+
+        assertEquals(DocErrorCode.TITLE_DUPLICATION, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
+++ b/src/test/java/io/ejangs/docsa/domain/doc/util/DocTestUtils.java
@@ -11,7 +11,7 @@ import io.ejangs.docsa.domain.commit.document.CommitBlockSequence;
 import io.ejangs.docsa.domain.commit.entity.Commit;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto;
 import io.ejangs.docsa.domain.doc.dto.RecentActivityDto.RecentType;
-import io.ejangs.docsa.domain.doc.dto.response.DocListResponse;
+import io.ejangs.docsa.domain.doc.dto.response.DocPageResponse;
 import io.ejangs.docsa.domain.doc.entity.Doc;
 import io.ejangs.docsa.domain.doc.entity.Edge;
 import io.ejangs.docsa.domain.save.dao.mongodb.SaveContentRepository;
@@ -352,9 +352,9 @@ public class DocTestUtils {
         return uniqueIdCounter++;
     }
 
-    public static Page<DocListResponse> convertToDocListResponsePage(List<Doc> docs,
+    public static Page<DocPageResponse> convertToDocListResponsePage(List<Doc> docs,
             Pageable pageable) {
-        List<DocListResponse> responses = docs.stream()
+        List<DocPageResponse> responses = docs.stream()
                 .map(doc -> {
                     Long docId = doc.getId();
                     String title = doc.getTitle();
@@ -382,7 +382,7 @@ public class DocTestUtils {
                             .findFirst()
                             .orElse(null);
 
-                    return new DocListResponse(docId, title, createdAt, updatedAt, preview, recent);
+                    return new DocPageResponse(docId, title, createdAt, updatedAt, preview, recent);
                 })
                 .toList();
 

--- a/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoDeleteRetryServiceTest.java
+++ b/src/test/java/io/ejangs/docsa/mongoDeleteSystem/MongoDeleteRetryServiceTest.java
@@ -21,6 +21,7 @@ import io.ejangs.docsa.global.mongo.deletion.dao.mysql.MongoDeleteFailureReposit
 import io.ejangs.docsa.global.mongo.deletion.entity.MongoDeleteFailure;
 import java.time.Duration;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,8 +67,13 @@ class MongoDeleteRetryServiceTest {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
-    @BeforeEach
-    void setUp() {
+    @AfterEach
+    void cleanup() {
+        userRepository.deleteAll();
+        docRepository.deleteAll();
+        commitBlockSequenceRepository.deleteAll();
+        blockRepository.deleteAll();
+        saveContentRepository.deleteAll();
         mongoDeleteFailureRepository.deleteAll();
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -49,3 +49,7 @@ auth:
 default:
   branch: main
 
+app:
+  cors:
+    allowed-origin:
+


### PR DESCRIPTION
## 🛰️ Issue Number
- #176 

## 🪐 작업 내용
### 변경 내용
#### 문서 생성 로직에 보상트랜잭션 도입
```
[DocService]
    │
    ▼
[DocCreateOrchestrator]  ── (1) SaveContent 저장 (Mongo)
    │
    ▼
[DocCreateMySqlTxService] ── (2) Doc/Branch/Save 저장 (MySQL)
    │
    ├─ 성공 → 응답 반환
    │
    └─ 실패 → [MongoDeleteRetryService] (3) 보상 삭제 (Mongo, Retry/Recover)
```
#### Command / Query 책임 분리
- 조회 로직을 DocQueryService로 분리
- DocService에서 Repository 직접 접근 제거
#### 그 외
- 프로파일별 CORS 허용 도메인 분리
- MongoDeleteRetryService 벌크 삭제 방식으로 개선
- 맘에 안드는 메소드명 클래스명 변수명 변경


#### 테스트
- 정상 성공 케이스
- MySQL 실패 + 보상 삭제 성공 케이스
- MySQL 실패 + 보상 삭제 3회 실패 시 Failure 저장 검증

### 참고사항
- 현재 문서 생성로직에서는 하나의 saveContent 문서에 대한 생성만 이루어지기 때문에 따로 트랜잭션도 걸지않고 MongoTxService로 분리도 하지 않았습니다. 하지만 다른 도메인에서는 분리 및 트랜잭션을 설정해야할 것 같습니다.
- DocQueryService로 분리하는 과정에서 다른 도메인을 살짝쿵 건들였습니다.
- 이 dev에 pr전에 staging프론트에서 테스트를 진행할 예정입니다. 이상한 점이 없으면 dev에 머지후, 다른 도메인 작업을 이어가려 합니다. (https://staging.docsa-4hh.pages.dev/)
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?