### PR TITLE
Chore: 인증서 갱신 스크립트 및 구조 변경

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -18,6 +18,7 @@ fi
 
 IMAGE_BASE="${IMAGE_BASE:-ghcr.io/prgrms-web-devcourse-final-project/docsa-backend}"
 SERVICE="${SERVICE:-app}"
+PROJECT="docsa-$TARGET"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
 
 cd "$(dirname "$0")"
@@ -46,7 +47,7 @@ EOF
 fi
 
 # docker compose 인자 구성 (-p로 프로젝트 격리, --env-file로 env 명시)
-ARGS=(-f "$COMPOSE_FILE")
+ARGS=(-f "$COMPOSE_FILE" -p "$PROJECT")
 [[ -n "$OVR" ]] && ARGS+=(-f "$OVR")
 ARGS+=(--env-file "$ENV_FILE")
 
@@ -57,7 +58,7 @@ echo "[deploy] compose=$COMPOSE_FILE env=$ENV_FILE service=$SERVICE"
 docker compose "${ARGS[@]}" config >/dev/null
 
 # 2) 이미지 풀 + 대상 서비스만 업데이트
-docker compose "${ARGS[@]}" pull "$SERVICE" || true
+docker compose "${ARGS[@]}" pull "$SERVICE"
 docker compose "${ARGS[@]}" up -d "$SERVICE"
 
 # 3) 컨테이너 ID를 compose로 조회(이름 하드코딩 회피)

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       --agree-tos --non-interactive
       --no-eff-email
 
-  # 자동 갱신 데몬(하루마다 확인, 갱신되면 nginx 리로드)
+  # 인증서 갱신용 컨테이너(cron)
   certbot_renew:
     image: certbot/certbot:latest
     container_name: docsa-certbot-renew
@@ -114,33 +114,6 @@ services:
       - ./certbot/www:/var/www/certbot:rw
       - ./certbot/etc:/etc/letsencrypt:rw
       - ./certbot/logs:/var/log/letsencrypt:rw
-      - /var/run/docker.sock:/var/run/docker.sock:rw
-    entrypoint: >
-      sh -c '
-        set -eu
-  
-        # curl 없으면 설치
-        if ! command -v curl >/dev/null 2>&1; then
-          if command -v apk >/dev/null 2>&1; then
-            apk add --no-cache curl >/dev/null 2>&1
-          else
-            echo "[ERROR] curl not found and apk not available. Need curl-capable image." >&2
-            exit 1
-          fi
-        fi
-  
-        while :; do
-          # renew 실행
-          certbot renew --webroot -w /var/www/certbot --quiet || true
-  
-          # nginx 무중단 reload (Docker Engine API)
-          curl -sS --unix-socket /var/run/docker.sock \
-            -X POST "http://localhost/v1.41/containers/docsa-nginx/kill?signal=HUP" \
-            >/dev/null 2>&1 || true
-  
-          sleep 24h
-        done
-      '
 
   # ===== METRICS =====
   cadvisor:

--- a/infra/scripts/cert_renew.sh
+++ b/infra/scripts/cert_renew.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+out="$(docker compose run --rm --no-deps certbot_renew \
+  renew --webroot -w /var/www/certboXt)"
+
+echo "$out"
+
+# "갱신됨"일 때만 reload
+if echo "$out" | grep -Eqi "successfully renewed|Congratulations|renewed"; then
+  docker kill -s HUP docsa-nginx 2>/dev/null || true
+  docker kill -s HUP docsa-nginx-stg 2>/dev/null || true
+fi

--- a/infra/scripts/check_cert_expiry.sh
+++ b/infra/scripts/check_cert_expiry.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="/srv/docsa/infra/.secrets/docsa-alert.env"
+THRESHOLD_DAYS=14
+
+DOMAINS=(
+  "api.docsa.o-r.kr:443"
+  "stg.api.docsa.o-r.kr:8443"
+)
+
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+notify_slack () {
+  local msg="$1"
+  [[ -z "${SLACK_WEBHOOK_URL:-}" ]] && return 0
+  curl -sS -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":${msg@Q}}" \
+    "$SLACK_WEBHOOK_URL" >/dev/null || true
+}
+
+failed=0
+now_epoch=$(date -u +%s)
+
+for target in "${DOMAINS[@]}"; do
+  host="${target%%:*}"
+  port="${target##*:}"
+
+  exp_date=$(echo | openssl s_client -connect "$host:$port" -servername "$host" 2>/dev/null \
+    | openssl x509 -noout -enddate \
+    | cut -d= -f2 || true)
+
+  [[ -z "$exp_date" ]] && {
+    notify_slack "❌ $host:$port 인증서 만료일 조회 실패"
+    failed=1
+    continue
+  }
+
+  exp_epoch=$(date -u -d "$exp_date" +%s)
+  remain_days=$(( (exp_epoch - now_epoch) / 86400 ))
+
+  if (( remain_days <= THRESHOLD_DAYS )); then
+    notify_slack "⚠️ $host:$port 인증서 만료 임박 D-${remain_days} (만료: $exp_date UTC)"
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/infra/scripts/check_server_alive.sh
+++ b/infra/scripts/check_server_alive.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="/srv/docsa/infra/.secrets/docsa-alert.env"
+TIMEOUT=5
+
+TARGETS=(
+  "api.docsa.o-r.kr:443"
+  "stg.api.docsa.o-r.kr:8443"
+)
+
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+notify_slack () {
+  local msg="$1"
+  [[ -z "${SLACK_WEBHOOK_URL:-}" ]] && return 0
+  curl -sS -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":${msg@Q}}" \
+    "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
+}
+
+for target in "${TARGETS[@]}"; do
+  host="${target%%:*}"
+  port="${target##*:}"
+
+  if ! timeout "${TIMEOUT}" bash -c "</dev/tcp/${host}/${port}" 2>/dev/null; then
+    notify_slack "🚨 아아 공습경보 서버 불량: ${host}:${port}"
+  fi
+done


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
인증서 자동 갱신 구조 개선
	•	certbot_renew 컨테이너 내부 무한 루프 방식 제거
	•	cron 기반 호스트 실행 방식으로 전환
	•	infra/scripts/cert_renew.sh 스크립트 추가
	•	갱신 시 nginx(dev/stg) 무중단 reload 적용

Infra 구조 정리
	•	docker-compose에서 certbot entrypoint 제거
	•	불필요한 docker.sock 의존 제거
	•	배포 스크립트(deploy.sh) 정리

운영 안정성 개선
	•	인증서 만료 체크 및 서버 생존 체크 스크립트 정리
	•	cron 작업 root 기준으로 통합 관리

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?