### PR TITLE
chore: 운영과 스테이징 모니터링 통합

### DIFF
--- a/docs/superpowers/plans/2026-08-05-monitoring-consolidation.md
+++ b/docs/superpowers/plans/2026-08-05-monitoring-consolidation.md
@@ -1,0 +1,91 @@
+# Docsa Monitoring Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Docsa 운영과 스테이징의 중복 모니터링을 한 스택으로 통합하고 스테이징 모니터링 데이터 볼륨을 삭제한다.
+
+**Architecture:** 운영 Compose가 공용 관측 스택을 소유한다. 운영 Prometheus는 `docsa_monitoring_net`을 통해 스테이징 앱과 MySQL Exporter도 수집하며 로그는 한 Promtail이 project label로 Docsa만 선별한다.
+
+**Tech Stack:** Docker Compose, Prometheus, Grafana, Loki, Promtail, cAdvisor, Node Exporter, Bash
+
+## Global Constraints
+
+- `stg_mysql_data`와 `mailpit_data`는 삭제하지 않는다.
+- 스테이징 모니터링 볼륨은 통합 target 검증 후 즉시 삭제한다.
+- 운영과 스테이징 애플리케이션은 모니터링 장애에 의존하지 않는다.
+- 모든 커밋 메시지는 한글 Conventional Commit 형식을 사용한다.
+
+---
+
+### Task 1: 통합 구성 계약
+
+**Files:**
+- Modify: `infra/tests/shared_gateway_contract_test.sh`
+- Modify: `infra/docker-compose.yml`
+- Modify: `infra/docker-compose.stg.yml`
+- Modify: `infra/prometheus/prometheus.yml`
+- Modify: `infra/promtail/config.yml`
+- Modify: `infra/loki/config.yml`
+- Modify: `infra/nginx/nginx.stg.conf`
+
+**Interfaces:**
+- Produces: `docsa_monitoring_net`, 환경별 Prometheus job, 단일 Promtail project filter
+
+- [ ] **Step 1: 실패하는 통합 계약 테스트 작성**
+
+  스테이징 중복 서비스 부재, 공유 네트워크, 환경별 target, 로그 필터, 보존 기간과 Grafana redirect를 검사한다.
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+  Run: `bash infra/tests/shared_gateway_contract_test.sh`
+
+  Expected: 기존 스테이징 모니터링 서비스와 누락된 공유 설정 때문에 실패한다.
+
+- [ ] **Step 3: 최소 Compose 및 설정 변경**
+
+  운영 관측 스택을 유지하고 스테이징 중복 여섯 서비스를 제거한다. 앱, MySQL Exporter와 Prometheus를 공유 네트워크로 연결한다.
+
+- [ ] **Step 4: 테스트와 Compose 렌더링 확인**
+
+  Run: `bash infra/tests/shared_gateway_contract_test.sh`
+
+  Run on server secrets: `docker compose -f infra/docker-compose.yml config --quiet && docker compose -f infra/docker-compose.stg.yml config --quiet`
+
+- [ ] **Step 5: 커밋**
+
+  Run: `git commit -m "chore: Docsa 모니터링 스택 통합"`
+
+### Task 2: MySQL slow log 분리
+
+**Files:**
+- Modify: `infra/docker-compose.yml`
+- Modify: `infra/docker-compose.stg.yml`
+- Modify: `infra/promtail/config.yml`
+- Modify: `infra/tests/shared_gateway_contract_test.sh`
+
+**Interfaces:**
+- Produces: `/mnt/mysql-logs/prod/slow.log`, `/mnt/mysql-logs/staging/slow.log`
+
+- [ ] **Step 1: 실패하는 slow log 경로 테스트 작성**
+- [ ] **Step 2: 테스트 실패 확인**
+- [ ] **Step 3: 운영 및 스테이징 bind mount와 Promtail job 분리**
+- [ ] **Step 4: 계약 테스트 통과 확인**
+- [ ] **Step 5: `fix: 운영과 스테이징 MySQL slow log 경로 분리` 커밋**
+
+### Task 3: 홈서버 마이그레이션
+
+**Files:**
+- Deploy: `/srv/docsa`
+
+**Interfaces:**
+- Consumes: 병합된 Docsa staging 커밋
+- Produces: 단일 Docsa 관측 스택
+
+- [ ] **Step 1: 기존 컨테이너, 볼륨과 target 이름 재확인**
+- [ ] **Step 2: `docsa_monitoring_net` 생성 및 서버 pull**
+- [ ] **Step 3: slow log 디렉터리 생성과 MySQL 컨테이너 순차 재생성**
+- [ ] **Step 4: 운영 모니터링과 스테이징 앱 및 Exporter 반영**
+- [ ] **Step 5: 운영 및 스테이징 target과 외부 서비스 검증**
+- [ ] **Step 6: 스테이징 중복 모니터링 컨테이너 제거**
+- [ ] **Step 7: `stg_prom_data`, `stg_loki_data`, `stg_grafana_data` 실제 볼륨 이름 확인 후 삭제**
+- [ ] **Step 8: MySQL 및 Mailpit 볼륨 보존과 Git 상태 확인**

--- a/docs/superpowers/specs/2026-08-05-monitoring-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-05-monitoring-consolidation-design.md
@@ -1,0 +1,92 @@
+# Docsa 운영 및 스테이징 모니터링 통합 설계
+
+## 배경
+
+Docsa 운영과 스테이징 Compose는 Prometheus, Grafana, Loki, Promtail, cAdvisor와 Node Exporter를 각각 실행한다. 두 cAdvisor와 Node Exporter는 같은 홈서버를 중복 관찰하고, 두 Promtail은 필터 없이 같은 Docker 로그와 syslog를 각각의 Loki에 저장한다.
+
+현재 모니터링 컨테이너는 약 1.86GiB를 사용한다. 스테이징 중복 스택은 약 724MiB를 사용하며 두 Loki 데이터 경로는 각각 약 2.7GiB다. 운영과 스테이징 MySQL도 동일한 호스트 `./mysql/logs` 경로에 slow log를 기록한다.
+
+## 목표
+
+- Prometheus, Grafana, Loki, Promtail, cAdvisor와 Node Exporter를 운영 Compose의 한 세트로 통합한다.
+- 운영과 스테이징 애플리케이션 및 MySQL 메트릭을 환경 label로 구분한다.
+- Promtail은 Compose project가 `docsa` 또는 `docsa-stg`인 컨테이너 로그만 한 번 수집한다.
+- 운영과 스테이징 MySQL slow log 경로를 분리한다.
+- Prometheus는 15일, Loki는 7일 보존한다.
+- 검증 후 스테이징 Prometheus, Grafana와 Loki 데이터 볼륨을 즉시 삭제한다.
+
+## 통합 구조
+
+```text
+Docsa Prometheus
+├─ docsa-app:9091
+├─ docsa-app-stg:9091
+├─ mysqld-exporter:9104
+├─ mysqld-exporter-stg:9104
+├─ cadvisor:8080
+└─ node-exporter:9100
+
+Docsa Promtail
+├─ compose_project=docsa
+└─ compose_project=docsa-stg
+
+Docsa Grafana
+├─ Prometheus
+└─ Loki
+```
+
+운영 Prometheus와 스테이징 앱 및 MySQL Exporter는 호스트에 게시하지 않는 외부 Docker 네트워크 `docsa_monitoring_net`으로 연결한다. 운영 내부 대상은 기존 `docsa_net`을 유지한다.
+
+## 스테이징 변경
+
+스테이징 Compose에서 다음 서비스를 제거한다.
+
+- `cadvisor`
+- `node_exporter`
+- `prometheus`
+- `loki`
+- `promtail`
+- `grafana`
+
+스테이징 앱과 MySQL Exporter는 유지하고 `docsa_monitoring_net`에 추가로 참여한다. 스테이징 `/grafana/`는 운영 Grafana 주소로 redirect한다.
+
+## 로그 경계
+
+- 운영 MySQL: `./mysql/logs/prod`
+- 스테이징 MySQL: `./mysql/logs/staging`
+- 기존 `./mysql/logs/slow.log`는 마이그레이션 백업으로 보존한다.
+- Promtail Docker discovery는 `docsa|docsa-stg` project 정규식으로 제한한다.
+- MySQL slow log는 운영과 스테이징 경로를 별도 job과 environment label로 수집한다.
+
+## 보존 기간
+
+- Prometheus: `--storage.tsdb.retention.time=15d`
+- Loki: `retention_period: 168h`
+
+## 배포와 삭제
+
+1. `docsa_monitoring_net`을 한 번 생성한다.
+2. 운영 모니터링 설정을 반영하고 Prometheus를 해당 네트워크에 연결한다.
+3. 스테이징 앱과 MySQL Exporter를 해당 네트워크에 연결한다.
+4. 운영 Prometheus에서 운영 및 스테이징 target이 모두 UP인지 확인한다.
+5. 통합 Grafana와 Loki를 확인한다.
+6. 스테이징 중복 모니터링 컨테이너만 제거한다.
+7. 정확한 볼륨 이름을 다시 확인한다.
+8. 스테이징 Prometheus, Grafana와 Loki 볼륨을 즉시 삭제한다.
+
+삭제 대상은 모니터링 데이터 볼륨 세 개로 제한한다. `stg_mysql_data`와 `mailpit_data`는 삭제하지 않는다.
+
+## 검증
+
+- Compose 계약 테스트에서 스테이징 중복 서비스 제거를 확인한다.
+- Prometheus 설정 검사에서 운영 및 스테이징 app과 MySQL job을 확인한다.
+- Promtail 설정 검사에서 project filter와 두 slow log 경로를 확인한다.
+- 운영 Prometheus target API에서 모든 target이 UP이다.
+- 운영 및 스테이징 Docsa health가 정상이다.
+- 운영 Grafana health가 정상이다.
+- 스테이징 `/grafana/`가 운영 주소로 redirect한다.
+- 제거 후 스테이징 MySQL, 앱, Nginx와 Mailpit은 계속 실행된다.
+
+## 롤백
+
+스테이징 모니터링 볼륨은 사용자 요청에 따라 즉시 삭제하므로 과거 스테이징 대시보드, 메트릭과 로그 데이터는 복구하지 않는다. 구성 장애 시 Git 이전 커밋으로 돌아가 스테이징 모니터링 컨테이너를 새 볼륨으로 재생성할 수 있다. MySQL과 Mailpit 볼륨은 삭제 대상이 아니므로 애플리케이션 데이터에는 영향을 주지 않는다.

--- a/infra/README.md
+++ b/infra/README.md
@@ -17,10 +17,22 @@ Docsa Compose는 애플리케이션, 데이터베이스, 모니터링과 스테�
 ## Compose 책임
 
 - docker-compose.yml: 운영 애플리케이션, MySQL, 메트릭, 로그 및 대시보드
-- docker-compose.stg.yml: 스테이징 애플리케이션, MySQL, Nginx, Mailpit 및 관측 구성
+- docker-compose.stg.yml: 스테이징 애플리케이션, MySQL, Nginx와 Mailpit
 - deploy.sh: 브랜치 이미지 태그를 적용하고 애플리케이션 health를 확인
 
 운영 Nginx와 Certbot 서비스는 공용 Gateway로 이전했으므로 이 저장소에서 다시 실행하지 않습니다.
+
+## 모니터링
+
+운영 Compose가 Prometheus, Grafana, Loki, Promtail, cAdvisor와 Node Exporter를 한 세트만 실행합니다. Prometheus는 외부 `docsa_monitoring_net`을 통해 스테이징 앱과 MySQL Exporter도 수집하며 `environment` label로 운영과 스테이징을 구분합니다.
+
+Promtail은 Docker Compose project가 `docsa` 또는 `docsa-stg`인 컨테이너 로그만 Loki에 전달합니다. 운영과 스테이징 MySQL slow log는 각각 `mysql/logs/prod`와 `mysql/logs/staging`에 기록합니다.
+
+최초 반영 전 네트워크를 한 번 생성합니다.
+
+    docker network inspect docsa_monitoring_net >/dev/null 2>&1 || docker network create docsa_monitoring_net
+
+Prometheus 데이터는 15일, Loki 로그는 7일 보존합니다. 스테이징 `/grafana/` 요청은 통합 운영 Grafana로 이동합니다.
 
 ## 모니터링 cron
 

--- a/infra/docker-compose.stg.yml
+++ b/infra/docker-compose.stg.yml
@@ -11,6 +11,7 @@ services:
           condition: service_healthy
     networks:
       - docsa_stg_net
+      - docsa_monitoring_net
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9091/actuator/health"]
       interval: 30s
@@ -46,9 +47,10 @@ services:
     volumes:
       - stg_mysql_data:/var/lib/mysql
       - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf:ro
-      - ./mysql/logs:/var/log/mysql
+      - ./mysql/logs/staging:/var/log/mysql
     networks:
       - docsa_stg_net
+      - docsa_monitoring_net
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
       interval: 10s
@@ -95,97 +97,12 @@ services:
       - docsa_stg_net
 
 
- # ===== METRICS =====
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    container_name: cadvisor-stg
-    restart: unless-stopped
-    privileged: true
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    networks:
-      - docsa_stg_net
-
-  node_exporter:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-stg
-    restart: unless-stopped
-    pid: host
-    command: ['--path.rootfs=/host']
-    volumes:
-      - /:/host:ro,rslave
-    networks:
-      - docsa_stg_net
-
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus-stg
-    restart: unless-stopped
-    command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--web.enable-remote-write-receiver"
-    ports:
-      - "${PROMETHEUS_BIND_ADDR:-127.0.0.1}:9090:9090"
-    depends_on:
-      - cadvisor
-    volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - stg_prom_data:/prometheus
-    networks:
-      - docsa_stg_net
-
-# ===== LOGS =====
-  loki:
-    image: grafana/loki:3.5.5
-    container_name: loki-stg
-    restart: unless-stopped
-    command: ["-config.file=/etc/loki/config.yml"]
-    volumes:
-      - ./loki/config.yml:/etc/loki/config.yml:ro
-      - stg_loki_data:/loki
-    networks:
-      - docsa_stg_net
-
-  promtail:
-    image: grafana/promtail:3.5
-    container_name: promtail-stg
-    restart: unless-stopped
-    command: ["-config.file=/etc/promtail/config.yml"]
-    volumes:
-      - ./promtail/config.yml:/etc/promtail/config.yml:ro
-      - /var/log:/var/log:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./mysql/logs:/mnt/mysql-logs:ro
-    networks: [docsa_stg_net]
-
-# ===== DASHBOARD =====
-  grafana:
-    image: grafana/grafana-oss:latest
-    container_name: grafana-stg
-    restart: unless-stopped
-    depends_on: [prometheus, loki]
-    volumes:
-      - stg_grafana_data:/var/lib/grafana
-      - ./grafana/provisioning/datasources/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
-    environment:
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD}
-      GF_SERVER_ROOT_URL: 'https://stg.api.docsa.o-r.kr/grafana/'
-      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
-    networks: [docsa_stg_net]
-
-
 volumes:
   stg_mysql_data:
-  stg_prom_data:
-  stg_loki_data:
-  stg_grafana_data:
   mailpit_data:
 
 networks:
   docsa_stg_net:
+  docsa_monitoring_net:
+    external: true
+    name: docsa_monitoring_net

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
       - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf:ro
-      - ./mysql/logs:/var/log/mysql
+      - ./mysql/logs/prod:/var/log/mysql
     networks:
       - docsa_net
     healthcheck:
@@ -88,6 +88,10 @@ services:
     image: prom/prometheus:latest
     container_name: prometheus
     restart: unless-stopped
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
     depends_on:
       - cadvisor
     volumes:
@@ -95,6 +99,7 @@ services:
       - prom_data:/prometheus
     networks:
       - docsa_net
+      - docsa_monitoring_net
 
   # ===== LOGS =====
   loki:
@@ -146,3 +151,6 @@ volumes:
 
 networks:
   docsa_net:
+  docsa_monitoring_net:
+    external: true
+    name: docsa_monitoring_net

--- a/infra/loki/config.yml
+++ b/infra/loki/config.yml
@@ -23,5 +23,13 @@ schema_config:
       schema: v13
       index: { prefix: index_, period: 24h }
 
+limits_config:
+  retention_period: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
 ruler:
   alertmanager_url: http://localhost:9093

--- a/infra/nginx/nginx.stg.conf
+++ b/infra/nginx/nginx.stg.conf
@@ -53,19 +53,7 @@ http {
 
 
 		location /grafana/ {
-			proxy_pass http://grafana:3000;
-
-			proxy_http_version 1.1;
-			proxy_set_header Upgrade $http_upgrade;
-			proxy_set_header Connection "upgrade";
-			proxy_read_timeout 3600;
-
-			proxy_set_header Host $host;
-			proxy_set_header X-Real-IP $remote_addr;
-			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-			proxy_set_header X-Forwarded-Proto $scheme;
-			proxy_set_header X-Forwarded-Host $host;
-			proxy_redirect off;
+			return 302 https://api.docsa.o-r.kr$request_uri;
 		}
 
 
@@ -84,4 +72,3 @@ http {
 
   }
 }
-

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -4,11 +4,17 @@ global:
 
 scrape_configs:
   # Spring Actuator
-  - job_name: 'spring-app'
+  - job_name: 'docsa-production'
     metrics_path: /actuator/prometheus
     static_configs:
-      - targets: ['app:9091']
-        labels: { app: docsa }
+      - targets: ['docsa-app:9091']
+        labels: { app: docsa, environment: production }
+
+  - job_name: 'docsa-staging'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['docsa-app-stg:9091']
+        labels: { app: docsa, environment: staging }
 
   # 컨테이너 리소스
   - job_name: 'cadvisor'
@@ -20,6 +26,12 @@ scrape_configs:
     static_configs:
       - targets: ['node_exporter:9100']  # node_exporter(host 네트워크)
 
-  - job_name: 'mysql'
+  - job_name: 'mysql-production'
     static_configs:
       - targets: ['mysqld-exporter:9104']
+        labels: { app: docsa, environment: production }
+
+  - job_name: 'mysql-staging'
+    static_configs:
+      - targets: ['mysqld-exporter-stg:9104']
+        labels: { app: docsa, environment: staging }

--- a/infra/promtail/config.yml
+++ b/infra/promtail/config.yml
@@ -17,6 +17,9 @@ scrape_configs:
     pipeline_stages:
       - docker: {}
     relabel_configs:
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        regex: docsa|docsa-stg
+        action: keep
       - { source_labels: ['__meta_docker_container_name'], target_label: 'container', regex: '/(.*)' }
       - { source_labels: ['__meta_docker_container_label_com_docker_compose_service'], target_label: 'compose_service' }
       - { source_labels: ['__meta_docker_container_label_com_docker_compose_project'], target_label: 'compose_project' }
@@ -30,13 +33,28 @@ scrape_configs:
           job: syslog
           __path__: /var/log/syslog
 
-  - job_name: mysql-slowlog
+  - job_name: mysql-slowlog-production
     static_configs:
       - targets: [ localhost ]
         labels:
           job: mysql-slowlog
           compose_service: mysql
-          __path__: /mnt/mysql-logs/slow.log
+          environment: production
+          __path__: /mnt/mysql-logs/prod/slow.log
+    pipeline_stages:
+      - multiline:
+          firstline: '^# Time:'
+          max_lines: 200
+          max_wait_time: 3s
+
+  - job_name: mysql-slowlog-staging
+    static_configs:
+      - targets: [ localhost ]
+        labels:
+          job: mysql-slowlog
+          compose_service: mysql
+          environment: staging
+          __path__: /mnt/mysql-logs/staging/slow.log
     pipeline_stages:
       - multiline:
           firstline: '^# Time:'

--- a/infra/tests/shared_gateway_contract_test.sh
+++ b/infra/tests/shared_gateway_contract_test.sh
@@ -27,6 +27,39 @@ if printf '%s\n' "$staging_config" | grep -Fq '/srv/docsa/infra/certbot'; then
   fail "스테이징 Compose가 기존 Docsa 인증서 경로를 참조하면 안 됨"
 fi
 
+staging_services=$(docker compose -f "$INFRA_DIR/docker-compose.stg.yml" config --services)
+for duplicated_service in cadvisor node_exporter prometheus loki promtail grafana; do
+  if printf '%s\n' "$staging_services" | grep -Fxq "$duplicated_service"; then
+    fail "스테이징 Compose에 중복 모니터링 서비스 $duplicated_service 가 남아 있음"
+  fi
+done
+
+prod_config=$(docker compose -f "$INFRA_DIR/docker-compose.yml" config --no-interpolate)
+printf '%s\n' "$prod_config" | grep -Fq 'docsa_monitoring_net' ||
+  fail "운영 Prometheus가 공용 모니터링 네트워크를 사용해야 함"
+printf '%s\n' "$staging_config" | grep -Fq 'docsa_monitoring_net' ||
+  fail "스테이징 앱과 MySQL Exporter가 공용 모니터링 네트워크를 사용해야 함"
+
+grep -Fq -- '--storage.tsdb.retention.time=15d' "$INFRA_DIR/docker-compose.yml" ||
+  fail "Prometheus 보존 기간은 15일이어야 함"
+grep -Fq 'retention_period: 168h' "$INFRA_DIR/loki/config.yml" ||
+  fail "Loki 보존 기간은 7일이어야 함"
+
+for target in docsa-app:9091 docsa-app-stg:9091 mysqld-exporter:9104 mysqld-exporter-stg:9104; do
+  grep -Fq "$target" "$INFRA_DIR/prometheus/prometheus.yml" ||
+    fail "Prometheus 수집 대상 $target 이 필요함"
+done
+
+grep -Fq 'regex: docsa|docsa-stg' "$INFRA_DIR/promtail/config.yml" ||
+  fail "Promtail은 Docsa 운영과 스테이징 project만 수집해야 함"
+grep -Fq './mysql/logs/prod:/var/log/mysql' "$INFRA_DIR/docker-compose.yml" ||
+  fail "운영 MySQL slow log 경로를 분리해야 함"
+grep -Fq './mysql/logs/staging:/var/log/mysql' "$INFRA_DIR/docker-compose.stg.yml" ||
+  fail "스테이징 MySQL slow log 경로를 분리해야 함"
+
+grep -Fq 'return 302 https://api.docsa.o-r.kr$request_uri;' "$INFRA_DIR/nginx/nginx.stg.conf" ||
+  fail "스테이징 Grafana 경로를 통합 Grafana로 redirect해야 함"
+
 [ ! -e "$INFRA_DIR/nginx/nginx.conf" ] || fail "기존 운영 Nginx 설정이 없어야 함"
 [ ! -e "$INFRA_DIR/scripts/cert_renew.sh" ] || fail "기존 Docsa 인증서 갱신 스크립트가 없어야 함"
 


### PR DESCRIPTION
## 🛰️ Issue Number
- #207 

## 변경 배경
Docsa 운영과 스테이징 환경에서 Prometheus, Grafana, Loki, Promtail, cAdvisor, Node Exporter를 각각 실행하고 있었습니다.

두 환경이 같은 홈서버에서 동작하면서 다음 항목이 중복되고 있었습니다.

- cAdvisor와 Node Exporter가 같은 호스트 메트릭을 중복 수집
- 두 Promtail이 같은 Docker 로그와 syslog를 중복 수집
- 운영과 스테이징 Loki에 같은 로그가 중복 저장
- 운영과 스테이징 MySQL이 같은 slow log 디렉터리를 사용

확인 시점 기준 전체 모니터링 컨테이너는 약 1.86GiB를 사용했고, 스테이징 중복 스택은 약 724MiB를 사용하고 있었습니다.


## 🪐 작업 내용
### 모니터링 스택 통합

운영 Compose가 다음 모니터링 컨테이너를 한 세트만 관리하도록 변경했습니다.

- Prometheus
- Grafana
- Loki
- Promtail
- cAdvisor
- Node Exporter

스테이징 Compose에서는 위 중복 서비스를 제거하고 애플리케이션, MySQL, MySQL Exporter, Nginx, Mailpit만 유지합니다.

### 운영 및 스테이징 메트릭 통합

외부 Docker 네트워크 `docsa_monitoring_net`을 통해 운영 Prometheus가 다음 대상을 함께 수집합니다.

- Docsa 운영 애플리케이션
- Docsa 스테이징 애플리케이션
- 운영 MySQL Exporter
- 스테이징 MySQL Exporter
- 홈서버 cAdvisor
- 홈서버 Node Exporter

Prometheus label로 환경을 구분합니다.

```text
environment=production
environment=staging
```
### 로그 수집 범위 제한
Promtail이 다음 Docker Compose project의 로그만 수집하도록 제한했습니다.
docsa
docsa-stg
DevChat 등 다른 프로젝트의 컨테이너 로그는 Docsa Loki에 저장하지 않습니다.
### MySQL slow log 분리
운영과 스테이징 MySQL이 동일한 로그 디렉터리를 사용하던 구성을 분리했습니다.
운영: mysql/logs/prod
스테이징: mysql/logs/staging
Promtail에서도 두 slow log에 각각 환경 label을 부여합니다.
### 데이터 보존 기간 설정
모니터링 데이터가 계속 증가하지 않도록 보존 기간을 설정했습니다.
Prometheus: 15일
Loki: 7일
### Grafana 접근 통합
스테이징 /grafana/ 요청은 운영 통합 Grafana 주소로 이동하도록 변경했습니다.
https://stg.api.docsa.o-r.kr:8443/grafana/
→ https://api.docsa.o-r.kr/grafana/
## 기대 효과
스테이징 중복 모니터링 컨테이너 6개 제거
약 700MiB의 메모리 사용량 절감 예상
cAdvisor와 Node Exporter의 중복 호스트 수집 제거
Docker 로그와 syslog 중복 저장 제거
운영과 스테이징을 label 기반으로 한 Grafana에서 조회
MySQL slow log 환경별 분리
Prometheus와 Loki 데이터 증가 제한
## 검증
공용 Gateway 및 모니터링 통합 계약 테스트 통과
운영 Docker Compose 구성 검증 통과
스테이징 Docker Compose 구성 검증 통과
운영 및 스테이징 Prometheus target 구성 확인
Promtail Compose project 필터 확인
Prometheus 및 Loki 보존 기간 설정 확인
스테이징 중복 모니터링 서비스 제거 확인
MySQL slow log 경로 분리 확인
## 배포 시 작업
docsa_monitoring_net 생성
운영 Prometheus와 스테이징 앱 및 MySQL Exporter 연결
운영 및 스테이징 Prometheus target 상태 확인
통합 Grafana와 Loki 확인
스테이징 중복 모니터링 컨테이너 제거
스테이징 모니터링 데이터 볼륨 삭제
삭제 대상:
```
stg_prom_data
stg_loki_data
stg_grafana_data
```
보존 대상:
```
stg_mysql_data
mailpit_data
```
실제 Docker 볼륨 이름은 삭제 직전에 다시 확인합니다.
## 롤백
구성에 문제가 있으면 이전 Compose 설정으로 돌아가 스테이징 모니터링 컨테이너를 새 볼륨으로 재생성할 수 있습니다.
스테이징 Prometheus, Loki, Grafana 데이터 볼륨은 배포 검증 후 삭제할 예정이므로 기존 스테이징 메트릭, 로그, 대시보드 데이터는 복구 대상에 포함하지 않습니다.
MySQL과 Mailpit 데이터 볼륨은 삭제하지 않으므로 애플리케이션 데이터에는 영향을 주지 않습니다.


## 📚 Reference



## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
